### PR TITLE
int/int32_t/long int conversions have to be explicit

### DIFF
--- a/src/ProbingScene.cpp
+++ b/src/ProbingScene.cpp
@@ -98,7 +98,8 @@ public:
     }
     void onEntry(void* arg) override {
         if (initPrefs()) {
-            getPref("Offset", &_offset);
+            static_assert(sizeof(e4_t) == sizeof(int));
+            getPref("Offset", reinterpret_cast<int *>(&_offset));
             getPref("Travel", &_travel);
             getPref("Rate", &_rate);
             getPref("Retract", &_retract);

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -214,7 +214,7 @@ void Scene::getPref(const char* base_name, int axis, int* value) {
     if (!_prefs) {
         return;
     }
-    nvs_get_i32(_prefs, setting_name(base_name, axis), value);
+    nvs_get_i32(_prefs, setting_name(base_name, axis), reinterpret_cast<int32_t *>(value));
 }
 void Scene::setPref(const char* base_name, int axis, const char* value) {
     if (!_prefs) {


### PR DESCRIPTION
Without this patch you get compilation errors on Linux with pio 6.1

(since it is not immediately obvious that "e4_t" is really an int, I added a static_assert to be on the safe side)