### PR TITLE
Added option for more physical buttons via I2C expander PCF8574

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = m5dial
+default_envs = m5dial_more_buttons
 
 [common]
 build_flags = 
@@ -21,7 +21,7 @@ lib_deps =
     https://github.com/MitchBradley/GrblParser#9108f54
 build_src_filter = +<*.c> +<*.h> +<*.cpp> +<*.hpp>  -<System*.cpp> -<Hardware*.cpp> +<System.cpp> -<Touch_Class.cpp>
 
-[env:m5dial]
+[env:m5dial_base]
 ; Pendant based on M5Dial
 ; http://wiki.fluidnc.com/en/hardware/official/M5Dial_Pendant
 platform = espressif32
@@ -43,6 +43,23 @@ build_flags =
     -DDEBUG_TO_USB
 extra_scripts = git-version.py
 build_src_filter = ${common.build_src_filter} +<SystemArduino.cpp> +<HardwareM5Dial.cpp>
+
+[env:m5dial]
+; Pendant with two buttons
+extends = env:m5dial_base
+lib_deps =
+    ${env:m5dial_base.lib_deps}
+
+[env:m5dial_more_buttons]
+; Pendant based on M5Dial with more buttons through I2C PCF8574
+extends = env:m5dial_base
+lib_deps =
+    ${env:m5dial_base.lib_deps}
+    robtillaart/PCF8574@^0.4.1
+build_flags =
+    ${env:m5dial_base.build_flags}
+    -DFNC_BAUD=115200
+    -DI2C_BUTTONS
 
 [env:cyd_base]
 ; Pendant based on a 2432S028 "Cheap Yellow Display" and a hand wheel pulse encoder

--- a/src/HardwareM5Dial.hpp
+++ b/src/HardwareM5Dial.hpp
@@ -5,6 +5,15 @@ constexpr static const int DIAL_BUTTON_PIN = GPIO_NUM_42;
 #include "M5Dial.h"
 
 constexpr static const int FNC_UART_NUM = 1;
+#ifdef I2C_BUTTONS
+// PORT B is used for I2C buttons
+constexpr static const int I2C_BUTTONS_ADDR = 0x20;
+constexpr static const int I2C_BUTTONS_SDA  = GPIO_NUM_2;  // SDA
+constexpr static const int I2C_BUTTONS_SCL  = GPIO_NUM_1;  // SCL
+// PORT A is used for UART
+constexpr static const int PND_RX_FNC_TX_PIN = GPIO_NUM_15;
+constexpr static const int PND_TX_FNC_RX_PIN = GPIO_NUM_13;
+#else
 #ifdef UART_ON_PORT_B
 constexpr static const int RED_BUTTON_PIN    = GPIO_NUM_13;
 constexpr static const int GREEN_BUTTON_PIN  = GPIO_NUM_15;
@@ -27,5 +36,5 @@ constexpr static const int GREEN_BUTTON_PIN  = GPIO_NUM_2;
 constexpr static const int PND_RX_FNC_TX_PIN = GPIO_NUM_15;
 constexpr static const int PND_TX_FNC_RX_PIN = GPIO_NUM_13;
 #endif
-
 #define WAKEUP_GPIO RED_BUTTON_PIN
+#endif  // I2C_BUTTONS

--- a/src/MenuScene.cpp
+++ b/src/MenuScene.cpp
@@ -120,6 +120,19 @@ public:
         }
         reDisplay();
     }
+#ifdef I2C_BUTTONS    
+    void onOtherButtonPress() {      
+        extern m5::Button_Class& setXButton;
+        extern m5::Button_Class& setYButton;
+        extern m5::Button_Class& setZButton;
+        // handling other physical buttons for this scene
+        if ((setXButton.wasPressed() || setYButton.wasPressed() || setZButton.wasPressed())
+        &&  (state == Idle)) {
+            push_scene(&jogScene);
+            return;
+        }
+    }
+#endif
 } menuScene;
 
 Scene* initMenus() {

--- a/src/MultiJogScene.cpp
+++ b/src/MultiJogScene.cpp
@@ -98,6 +98,14 @@ public:
         }
         send_line(cmd.c_str());
     }
+
+    void zero_axis(int axis) {
+        std::string cmd = "G10L20P0";
+        cmd += axisNumToChar(axis);
+        cmd += "0";
+        send_line(cmd.c_str());
+    }
+
     void onEntry(void* arg) {
         if (arg && strcmp((const char*)arg, "Confirmed") == 0) {
             zero_axes();
@@ -107,6 +115,19 @@ public:
             for (size_t axis = 0; axis < 3; axis++) {
                 getPref("DistanceDigit", axis, &_dist_index[axis]);
             }
+        }
+        extern m5::Button_Class& setXButton;
+        extern m5::Button_Class& setYButton;
+        extern m5::Button_Class& setZButton;
+        if (setXButton.isPressed()) {
+            set_axis(0);
+        } else if (setYButton.isPressed()) {
+            set_axis(1);
+        } else if (setZButton.isPressed()) {
+            set_axis(2);
+        } else {
+            unselect_all();
+            select(0);
         }
     }
 
@@ -165,6 +186,7 @@ public:
                 if (++_dist_index[axis] >= max_index()) {
                     _dist_index[axis] = min_index();
                 }
+                set_dist_index(axis, _dist_index[axis]);
             }
         }
     }
@@ -208,6 +230,10 @@ public:
             the_axis = num_axes - 1;
         }
         select(the_axis);
+    }
+    void set_axis(int axis) {
+        unselect_all();
+        select(axis);
     }
     void touch_top() {
         prev_axis();
@@ -367,6 +393,48 @@ public:
             start_mpg_jog(delta);
         }
     }
+
+#ifdef I2C_BUTTONS
+    void onOtherButtonPress() {        
+        // handling physical buttons for this scene
+        extern m5::Button_Class& setXButton;
+        extern m5::Button_Class& setYButton;
+        extern m5::Button_Class& setZButton;
+        extern m5::Button_Class& changeStepButton;
+        if (setXButton.wasPressed()) {
+            set_axis(0);
+            reDisplay();
+        }
+        if (setYButton.wasPressed()) {
+            set_axis(1);
+            reDisplay();
+        }
+        if (setZButton.wasPressed()) {
+            set_axis(2);
+            reDisplay();
+        }
+        if (changeStepButton.wasPressed()) {
+            rotate_distance();
+            reDisplay();
+        }
+        // TODO isHolding action doesnt work
+        // long press - zero the X axis
+        if (setXButton.isHolding()) {
+            zero_axis(0);
+            reDisplay();
+        }
+        // long press - zero the Y axis
+        if (setYButton.isHolding()) {
+            zero_axis(1);
+            reDisplay();
+        }
+        // long press - zero the Z axis
+        if (setZButton.isHolding()) {
+            zero_axis(2);
+            reDisplay();
+        }
+    }
+#endif
 
     void onDROChange() {
         reDisplay();

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -62,16 +62,16 @@ void dispatch_button(bool pressed, int button) {
     switch (button) {
         case 0:
             if (pressed) {
-                current_scene->onRedButtonPress();
+                current_scene->onDialButtonPress();
             } else {
-                current_scene->onRedButtonRelease();
+                current_scene->onDialButtonRelease();
             }
             break;
         case 1:
             if (pressed) {
-                current_scene->onDialButtonPress();
+                current_scene->onRedButtonPress();
             } else {
-                current_scene->onDialButtonRelease();
+                current_scene->onRedButtonRelease();
             }
             break;
         case 2:
@@ -82,6 +82,7 @@ void dispatch_button(bool pressed, int button) {
             }
             break;
         default:
+            current_scene->onOtherButtonPress();
             break;
     }
 }

--- a/src/Scene.h
+++ b/src/Scene.h
@@ -39,6 +39,7 @@ public:
     virtual void onGreenButtonRelease() {}
     virtual void onDialButtonPress() {}
     virtual void onDialButtonRelease() {}
+    virtual void onOtherButtonPress() {}
     virtual void onTouchPress() {}
     virtual void onTouchRelease() {}
     virtual void onTouchClick() {}


### PR DESCRIPTION
First of all, thank you for your amazing Pendant FlidDial project – it's really well made!
I personally missed having more physical buttons, so I’ve modified the design to support multiple buttons.

Currently, there are **8 buttons** connected via the **PCF8574 I2C expander**, which also allows for easy future extension by daisy-chaining more expanders.

The additional buttons are currently used for **Multi Jog** functionality.
Two out of the eight buttons are not yet assigned to any specific function, leaving room for further customization.