### PR TITLE
Add WiFi connectivity as an alternative to UART

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/version.*
 *~
 junk
 release
+.DS_Store

--- a/platformio.ini
+++ b/platformio.ini
@@ -84,6 +84,7 @@ build_flags =
     -DCYD_BUTTONS
     -DRESISTIVE_CYD
     -DCAPACITIVE_CYD
+    ; -DDEV_SKIP_TO_SCENE
 
 # This is the original CYD build for a resistive CYD
 [env:cyd_resistive]

--- a/platformio.ini
+++ b/platformio.ini
@@ -84,7 +84,7 @@ build_flags =
     -DCYD_BUTTONS
     -DRESISTIVE_CYD
     -DCAPACITIVE_CYD
-    ; -DDEV_SKIP_TO_SCENE
+    ; -DDEV_SKIP_TO_SCENE=multiJogScene     ; uncomment to test different scenes
 
 # This is the original CYD build for a resistive CYD
 [env:cyd_resistive]
@@ -139,7 +139,7 @@ build_flags = -O0 -xc++ -std=c++17 -lSDL2
   ${common.build_flags}
   -DMACOS
   -DUSE_M5
-;   -DDEV_SKIP_TO_SCENE
+  ;-DDEV_SKIP_TO_SCENE=multiJogScene          ; uncomment to test different scenes
   -DM5GFX_BOARD=board_M5Dial
   -I"${sysenv.HOMEBREW_PREFIX}/include/SDL2"  ; arm64 Mac (Apple Silicon)
   -L"${sysenv.HOMEBREW_PREFIX}/lib"

--- a/platformio.ini
+++ b/platformio.ini
@@ -139,6 +139,7 @@ build_flags = -O0 -xc++ -std=c++17 -lSDL2
   ${common.build_flags}
   -DMACOS
   -DUSE_M5
+;   -DDEV_SKIP_TO_SCENE
   -DM5GFX_BOARD=board_M5Dial
   -I"${sysenv.HOMEBREW_PREFIX}/include/SDL2"  ; arm64 Mac (Apple Silicon)
   -L"${sysenv.HOMEBREW_PREFIX}/lib"

--- a/platformio.ini
+++ b/platformio.ini
@@ -121,3 +121,25 @@ build_flags = -O0 -xc++ -std=c++17 -lSDL2
   -I"C:/msys64/mingw32/include/SDL2"         ; for Windows SDL2
   -L"C:/msys64/mingw32/lib"                  ; for Windows SDL2
 build_src_filter = ${common.build_src_filter} +<SystemWindows.cpp> -<Encoder.cpp>
+
+[env:macos]
+; Runs the code on macOS with SDL2 — preview GUI without flashing
+; Requires SDL2: brew install sdl2
+; Build:  pio run -e macos
+; Run:    .pio/build/macos/program              (preview mode, no FluidNC)
+; Run:    .pio/build/macos/program /dev/tty.xxx (connected to FluidNC via serial)
+lib_deps =
+    ${common.lib_deps}
+    m5stack/M5Unified@^0.1.10
+platform = native
+build_type = release
+build_flags = -O0 -xc++ -std=c++17 -lSDL2
+  ${common.build_flags}
+  -DMACOS
+  -DUSE_M5
+  -DM5GFX_BOARD=board_M5Dial
+  -I"${sysenv.HOMEBREW_PREFIX}/include/SDL2"  ; arm64 Mac (Apple Silicon)
+  -L"${sysenv.HOMEBREW_PREFIX}/lib"
+  -I"/usr/local/include/SDL2"                  ; x86_64 Mac (Intel)
+  -L"/usr/local/lib"
+build_src_filter = ${common.build_src_filter} +<SystemMacOS.cpp> -<Encoder.cpp>

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,10 +37,11 @@ lib_deps =
     ${common.lib_deps}
     m5stack/M5Unified
     m5stack/M5Dial
+    links2004/WebSockets @ ^2.4.0
 build_flags =
     ${common.build_flags}
     -DUSE_M5
-    -DFNC_BAUD=1000000
+    -DUSE_WIFI
     -DDEBUG_TO_USB
 custom_filesystem_start=0x670000
 extra_scripts = ./build_merged.py
@@ -56,17 +57,18 @@ platform_packages =
     platformio/framework-arduinoespressif32@^3.20016.0
 monitor_filters=esp32_exception_decoder
 monitor_speed=115200
-upload_speed=921600
+upload_speed=748800
 board_build.filesystem = littlefs
 upload_flags=--no-stub
 lib_deps =
     ${common.lib_deps}
     ; m5stack/M5Unified
     LovyanGFX=https://github.com/lovyan03/LovyanGFX#develop
+    links2004/WebSockets @ ^2.4.0
 build_flags =
     ${common.build_flags}
     -DUSE_LOVYANGFX
-    -DFNC_BAUD=1000000
+    -DUSE_WIFI
     ;-DCORE_DEBUG_LEVEL=5
     -DCYD_BUTTONS
 custom_filesystem_start=0x290000

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,11 +12,12 @@
 default_envs = m5dial, cyddial
 
 [common]
-build_flags = 
+build_flags =
     !python ./git-version.py
     -DJSP_USE_CHARP
     -DE4_POS_T
     -DVERBATIM_GCODE_MODES
+    -DWEBSOCKETS_TCP_TIMEOUT=750
 lib_deps =
     https://github.com/MitchBradley/json-streaming-parser#charp-1.0.2
     https://github.com/MitchBradley/GrblParser#9108f54

--- a/src/Button.h
+++ b/src/Button.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "System.h"
+#include "Drawing.h"
+#include <functional>
+
+struct Button {
+    int         x, y, w, h;
+    const char* label;
+    int         fill_color;
+    int         outline_color;
+    int         text_color;
+    std::function<void()> onPress;
+
+    Button() : x(0), y(0), w(0), h(0), label(""), fill_color(NAVY),
+               outline_color(WHITE), text_color(WHITE), onPress(nullptr) {}
+
+    /**
+     * Update button geometry, label, colors, and callback all at once, then draw.
+     */
+    void set(int nx, int ny, int nw, int nh, const char* nlabel, int nfill, int noutline, int ntext,
+             std::function<void()> fn) {
+        x = nx; y = ny; w = nw; h = nh;
+        label = nlabel;
+        fill_color = nfill;
+        outline_color = noutline;
+        text_color = ntext;
+        onPress = fn;
+        draw();  // draw immediately
+    }
+
+    /**
+     * Draw the button.
+     */
+    void draw() const {
+        drawOutlinedRect(x, y, w, h, fill_color, outline_color);
+        centered_text(label, y + h / 2 + 3, text_color, SMALL);
+    }
+
+    /**
+     * Check if touch hits this button and invoke callback.
+     */
+    bool handleTouch(int tx, int ty) const {
+        if (tx >= x && tx <= x + w && ty >= y && ty <= y + h && onPress) {
+            onPress();
+            return true;
+        }
+        return false;
+    }
+};

--- a/src/ConfigItem.h
+++ b/src/ConfigItem.h
@@ -20,7 +20,11 @@ public:
     void         init() {
         _known = false;
         configRequests.push_back(this);
-        send_line(_name);
+        const char* p = _name;
+        while (*p) {
+            fnc_putchar(*p++);
+        }
+        fnc_putchar('\n');
     }
     void got(const char* s) {
         _known = true;
@@ -33,7 +37,7 @@ private:
     int _value;
 
 public:
-    IntConfigItem(const char* name) : ConfigItem(name) {}
+    IntConfigItem(const char* name) : ConfigItem(name), _value(0) {}
     int  get() { return _value; }
     void set(const char* s) { _value = atoi(s); }
 };
@@ -43,7 +47,7 @@ private:
     pos_t _value;
 
 public:
-    PosConfigItem(const char* name) : ConfigItem(name) {}
+    PosConfigItem(const char* name) : ConfigItem(name), _value(0) {}
     pos_t get() { return _value; }
     void  set(const char* s) { _value = atopos(s); }
 };
@@ -63,7 +67,7 @@ private:
     bool _value;
 
 public:
-    BoolConfigItem(const char* name) : ConfigItem(name) {}
+    BoolConfigItem(const char* name) : ConfigItem(name), _value(false) {}
     bool get() { return _value; }
     void set(const char* s) { _value = strcmp(s, "true") == 0; }
 };

--- a/src/ConfirmScene.cpp
+++ b/src/ConfirmScene.cpp
@@ -9,12 +9,12 @@ public:
     void onEntry(void* arg) { _msg = (const char*)arg; }
     void reDisplay() {
         background();
-        canvas.fillRoundRect(10, 90, 220, 60, 15, YELLOW);
 
+        drawOutlinedRect(10, 80, 230, 100, 0x001a4d, 0x4da6ff);
         size_t nl = _msg.find('\n');
         if (nl != std::string::npos) {
-            centered_text(_msg.substr(0, nl).c_str(), 108, BLACK, MEDIUM);
-            centered_text(_msg.substr(nl + 1).c_str(), 132, BLACK, MEDIUM);
+            centered_text(_msg.substr(0, nl).c_str(), 108, 0x4da6ff, SMALL);
+            centered_text(_msg.substr(nl + 1).c_str(), 132, 0x4da6ff, SMALL);
         } else {
             centered_text(_msg.c_str(), 120, BLACK, MEDIUM);
         }

--- a/src/ConfirmScene.cpp
+++ b/src/ConfirmScene.cpp
@@ -16,7 +16,7 @@ public:
             centered_text(_msg.substr(0, nl).c_str(), 108, 0x4da6ff, SMALL);
             centered_text(_msg.substr(nl + 1).c_str(), 132, 0x4da6ff, SMALL);
         } else {
-            centered_text(_msg.c_str(), 120, BLACK, MEDIUM);
+            centered_text(_msg.c_str(), 120, 0x4da6ff, MEDIUM);
         }
 
         drawButtonLegends("No", "Yes", "Back");

--- a/src/ConfirmScene.cpp
+++ b/src/ConfirmScene.cpp
@@ -1,11 +1,6 @@
 #include "Menu.h"
 #include <string>
 
-// Confirm scene needs a string to display.  It displays the string on
-// a background depicting the red and green buttons.
-// It pops when one of those buttons is pressed, or on back and flick back,
-// setting a variable to true iff the green button was pressed
-
 class ConfirmScene : public Scene {
     std::string _msg;
 
@@ -15,14 +10,24 @@ public:
     void reDisplay() {
         background();
         canvas.fillRoundRect(10, 90, 220, 60, 15, YELLOW);
-        centered_text(_msg.c_str(), 120, BLACK, MEDIUM);
+
+        size_t nl = _msg.find('\n');
+        if (nl != std::string::npos) {
+            centered_text(_msg.substr(0, nl).c_str(), 108, BLACK, MEDIUM);
+            centered_text(_msg.substr(nl + 1).c_str(), 132, BLACK, MEDIUM);
+        } else {
+            centered_text(_msg.c_str(), 120, BLACK, MEDIUM);
+        }
 
         drawButtonLegends("No", "Yes", "Back");
 
         refreshDisplay();
     }
     void onRedButtonPress() { pop_scene(nullptr); }
-    void onGreenButtonPress() { pop_scene((void*)"Confirmed"); }
+    void onGreenButtonPress() {
+        dbg_printf("ConfirmScene: Yes pressed\r\n");
+        pop_scene((void*)"Confirmed");
+    }
     void onDialButtonPress() { pop_scene(nullptr); }
 };
 ConfirmScene confirmScene;

--- a/src/DisplaySettingsScene.cpp
+++ b/src/DisplaySettingsScene.cpp
@@ -1,0 +1,65 @@
+// 2026 - Figamore
+// DisplaySettingsScene.cpp — lets the user cycle through CYD screen orientations.
+//
+// Turn the encoder to step through all available layouts (rotation × button position).
+
+#ifdef ARDUINO
+
+#include "DisplaySettingsScene.h"
+#include "Drawing.h"
+#include "System.h"
+#include "WiFiSetupScene.h"
+
+static const char* layout_names[] = {
+    "0\xb0  Btns Bottom",   // rotation 0, buttons below
+    "0\xb0  Btns Top",      // rotation 0, buttons above
+    "90\xb0 Btns Right",    // rotation 1, buttons right
+    "90\xb0 Btns Left",     // rotation 1, buttons left
+    "180\xb0 Btns Bottom",  // rotation 2, buttons below
+    "180\xb0 Btns Top",     // rotation 2, buttons above
+    "270\xb0 Btns Left",    // rotation 3, buttons left
+    "270\xb0 Btns Right",   // rotation 3, buttons right
+};
+static const int n_layout_names = sizeof(layout_names) / sizeof(layout_names[0]);
+
+void DisplaySettingsScene::onEntry(void* arg) {
+    reDisplay();
+}
+
+void DisplaySettingsScene::onEncoder(int delta) {
+    next_layout(delta);
+    reDisplay();
+}
+
+void DisplaySettingsScene::onDialButtonPress() {
+    activate_scene(&wifiSetupScene);
+}
+
+void DisplaySettingsScene::onRedButtonPress() {
+    activate_scene(&wifiSetupScene);
+}
+
+void DisplaySettingsScene::reDisplay() {
+    background();
+    drawMenuTitle("Display");
+    drawRect(55, 22, 130, 1, 0, DARKGREY);
+
+    char idx_buf[12];
+    snprintf(idx_buf, sizeof(idx_buf), "%d / %d", layout_num + 1, num_layouts);
+    centered_text(idx_buf, 70, DARKGREY, TINY);
+
+    // Layout name
+    const char* name = (layout_num >= 0 && layout_num < n_layout_names)
+                           ? layout_names[layout_num]
+                           : "Unknown";
+    centered_text(name, 100, WHITE, SMALL);
+
+    centered_text("Turn dial to rotate", 140, LIGHTGREY, TINY);
+
+    drawButtonLegends("Back", "", "Back");
+    refreshDisplay();
+}
+
+DisplaySettingsScene displaySettingsScene;
+
+#endif  // ARDUINO

--- a/src/DisplaySettingsScene.cpp
+++ b/src/DisplaySettingsScene.cpp
@@ -11,14 +11,14 @@
 #include "WiFiSetupScene.h"
 
 static const char* layout_names[] = {
-    "0\xb0  Btns Bottom",   // rotation 0, buttons below
-    "0\xb0  Btns Top",      // rotation 0, buttons above
-    "90\xb0 Btns Right",    // rotation 1, buttons right
-    "90\xb0 Btns Left",     // rotation 1, buttons left
-    "180\xb0 Btns Bottom",  // rotation 2, buttons below
-    "180\xb0 Btns Top",     // rotation 2, buttons above
-    "270\xb0 Btns Left",    // rotation 3, buttons left
-    "270\xb0 Btns Right",   // rotation 3, buttons right
+    "0 deg - Btns Bottom",   // rotation 0, buttons below
+    "0 deg - Btns Top",      // rotation 0, buttons above
+    "90 deg - Btns Right",    // rotation 1, buttons right
+    "90 deg - Btns Left",     // rotation 1, buttons left
+    "180 deg - Btns Bottom",  // rotation 2, buttons below
+    "180 deg - Btns Top",     // rotation 2, buttons above
+    "270 deg - Btns Left",    // rotation 3, buttons left
+    "270 deg - Btns Right",   // rotation 3, buttons right
 };
 static const int n_layout_names = sizeof(layout_names) / sizeof(layout_names[0]);
 
@@ -56,7 +56,7 @@ void DisplaySettingsScene::reDisplay() {
 
     centered_text("Turn dial to rotate", 140, LIGHTGREY, TINY);
 
-    drawButtonLegends("Back", "", "Back");
+    drawButtonLegends("Back", "", "");
     refreshDisplay();
 }
 

--- a/src/DisplaySettingsScene.h
+++ b/src/DisplaySettingsScene.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#ifdef ARDUINO
+
+#include "Scene.h"
+
+class DisplaySettingsScene : public Scene {
+public:
+    DisplaySettingsScene() : Scene("Display") {}
+
+    void onEntry(void* arg = nullptr) override;
+    void onEncoder(int delta) override;
+    void onDialButtonPress() override;
+    void onRedButtonPress() override;
+    void reDisplay() override;
+};
+
+extern DisplaySettingsScene displaySettingsScene;
+
+#endif  // ARDUINO

--- a/src/Drawing.cpp
+++ b/src/Drawing.cpp
@@ -321,7 +321,32 @@ void drawMenuTitle(const char* name) {
     centered_text(name, 12);
 }
 
+#ifdef USE_WIFI
+// Draw a 4-bar WiFi signal indicator in the top-left corner / arc.
+static void drawWiFiSignalOverlay() {
+    if (!wifi_is_connected()) return;   // No indicator while scanning / AP mode
+
+    int bars = wifi_signal_bars();      // 0–4
+
+    // Bar geometry: 4 columns, bottom-aligned, heights grow left → right.
+    static constexpr int W   = 3;                   // bar width  (px)
+    static constexpr int GAP = 2;                   // gap between bars (px)
+    static const     int H[] = { 4, 7, 10, 13 };   // heights: weak → strong
+
+    int x0    = round_display ? 31 : 5;
+    int y_bot = round_display ? 45 : 20;
+
+    for (int i = 0; i < 4; i++) {
+        int color = (i < bars) ? GREEN : DARKGREY;
+        canvas.fillRect(x0 + i * (W + GAP), y_bot - H[i], W, H[i], color);
+    }
+}
+#endif
+
 void refreshDisplay() {
+#ifdef USE_WIFI
+    drawWiFiSignalOverlay();
+#endif
     display.startWrite();
     canvas.pushSprite(sprite_offset.x, sprite_offset.y);
     display.endWrite();

--- a/src/Drawing.cpp
+++ b/src/Drawing.cpp
@@ -134,11 +134,13 @@ void drawStatus() {
         } else if (wifi_is_connected()) {
             bgColor = YELLOW;       // WiFi up, WebSocket still connecting
             line1   = "FluidNC";
-            line2   = "Connecting...";
+            static const char* nc_frames[] = { "Connecting", "Connecting.", "Connecting..", "Connecting..." };
+            line2   = nc_frames[(millis() / 400) % 4];
         } else {
             bgColor = RED;
             line1   = "WiFi";
-            line2   = "Connecting...";
+            static const char* wifi_frames[] = { "Scanning", "Scanning.", "Scanning..", "Scanning..." };
+            line2   = wifi_frames[(millis() / 400) % 4];
         }
         canvas.fillRoundRect((display_short_side() - width) / 2, y, width, height, 5, bgColor);
         centered_text(line1, y + height / 2 - 4, BLACK, SMALL);
@@ -185,10 +187,12 @@ void drawStatusSmall(int y) {
             label   = "AP Mode";
         } else if (wifi_is_connected()) {
             bgColor = YELLOW;   // WiFi up, WebSocket still connecting
-            label   = "WiFi OK";
+            static const char* nc_frames[] = { "FluidNC", "FluidNC.", "FluidNC..", "FluidNC..." };
+            label   = nc_frames[(millis() / 400) % 4];
         } else {
             bgColor = RED;
-            label   = "WiFi...";
+            static const char* wifi_frames[] = { "WiFi", "WiFi.", "WiFi..", "WiFi..." };
+            label   = wifi_frames[(millis() / 400) % 4];
         }
         canvas.fillRoundRect((display_short_side() - width) / 2, y, width, height, 5, bgColor);
         centered_text(label, y + height / 2 + 3, BLACK, TINY);

--- a/src/Drawing.cpp
+++ b/src/Drawing.cpp
@@ -122,8 +122,9 @@ void drawStatus() {
     static constexpr int height = 36;
 
 #ifdef USE_WIFI
-    if (state == Disconnected) {
+    if (state == Disconnected && !wifi_use_uart_mode()) {
         // Show WiFi connection progress instead of a plain "N/C" badge.
+        // Not shown in UART mode — fall through to the standard N/C display.
         int         bgColor;
         const char* line1;
         const char* line2;
@@ -178,8 +179,9 @@ void drawStatusSmall(int y) {
     static constexpr int height = 25;
 
 #ifdef USE_WIFI
-    if (state == Disconnected) {
+    if (state == Disconnected && !wifi_use_uart_mode()) {
         // Show WiFi connection progress in the compact badge.
+        // Not shown in UART mode — fall through to the standard N/C display.
         int         bgColor;
         const char* label;
         if (wifi_in_ap_mode()) {

--- a/src/Drawing.cpp
+++ b/src/Drawing.cpp
@@ -5,6 +5,9 @@
 #include "Drawing.h"
 #include "alarm.h"
 #include <map>
+#ifdef USE_WIFI
+#    include "WiFiConnection.h"
+#endif
 
 void drawBackground(int color) {
     canvas.fillSprite(color);
@@ -118,6 +121,32 @@ void drawStatus() {
     static constexpr int width  = 140;
     static constexpr int height = 36;
 
+#ifdef USE_WIFI
+    if (state == Disconnected) {
+        // Show WiFi connection progress instead of a plain "N/C" badge.
+        int         bgColor;
+        const char* line1;
+        const char* line2;
+        if (wifi_in_ap_mode()) {
+            bgColor = 0x8400;       // dark orange
+            line1   = "AP Setup";
+            line2   = "192.168.4.1";
+        } else if (wifi_is_connected()) {
+            bgColor = YELLOW;       // WiFi up, WebSocket still connecting
+            line1   = "FluidNC";
+            line2   = "Connecting...";
+        } else {
+            bgColor = RED;
+            line1   = "WiFi";
+            line2   = "Connecting...";
+        }
+        canvas.fillRoundRect((display_short_side() - width) / 2, y, width, height, 5, bgColor);
+        centered_text(line1, y + height / 2 - 4, BLACK, SMALL);
+        centered_text(line2, y + height / 2 + 12, BLACK, TINY);
+        return;
+    }
+#endif
+
     int bgColor = stateBGColors[state];
     if (bgColor != 1) {
         canvas.fillRoundRect((display_short_side() - width) / 2, y, width, height, 5, bgColor);
@@ -145,6 +174,27 @@ void drawStatusTiny(int y) {
 void drawStatusSmall(int y) {
     static constexpr int width  = 90;
     static constexpr int height = 25;
+
+#ifdef USE_WIFI
+    if (state == Disconnected) {
+        // Show WiFi connection progress in the compact badge.
+        int         bgColor;
+        const char* label;
+        if (wifi_in_ap_mode()) {
+            bgColor = 0x8400;   // dark orange
+            label   = "AP Mode";
+        } else if (wifi_is_connected()) {
+            bgColor = YELLOW;   // WiFi up, WebSocket still connecting
+            label   = "WiFi OK";
+        } else {
+            bgColor = RED;
+            label   = "WiFi...";
+        }
+        canvas.fillRoundRect((display_short_side() - width) / 2, y, width, height, 5, bgColor);
+        centered_text(label, y + height / 2 + 3, BLACK, TINY);
+        return;
+    }
+#endif
 
     int bgColor = stateBGColors[state];
     if (bgColor != 1) {

--- a/src/Encoder.cpp
+++ b/src/Encoder.cpp
@@ -1,9 +1,41 @@
-
 #include "Encoder.h"
-#include "sdkconfig.h"
-#include "driver/pcnt.h"
+
+#ifdef ARDUINO
+#    include <Arduino.h>
+#endif
+
+#ifndef USE_LOVYANGFX
+#    include "sdkconfig.h"
+#    include "driver/pcnt.h"
+#endif
 #include "driver/gpio.h"
 
+namespace {
+#ifdef USE_LOVYANGFX
+constexpr int8_t quadrature_lut[16] = {
+    0, -1, 1, 0,
+    1, 0, 0, -1,
+    -1, 0, 0, 1,
+    0, 1, -1, 0,
+};
+
+int     encoder_a_pin    = -1;
+int     encoder_b_pin    = -1;
+int16_t encoder_count    = 0;
+uint8_t encoder_state    = 0;
+
+uint8_t read_encoder_state() {
+    if (encoder_a_pin < 0 || encoder_b_pin < 0) {
+        return 0;
+    }
+    return (digitalRead(encoder_a_pin) << 1) | digitalRead(encoder_b_pin);
+}
+#else
+bool pcnt_ready = false;
+#endif
+}
+
+#ifndef USE_LOVYANGFX
 /* clang-format: off */
 void init_encoder(int a_pin, int b_pin) {
     pcnt_config_t enc_config = {
@@ -21,14 +53,20 @@ void init_encoder(int a_pin, int b_pin) {
         .unit    = PCNT_UNIT_0,
         .channel = PCNT_CHANNEL_0,
     };
-    pcnt_unit_config(&enc_config);
+    if (pcnt_unit_config(&enc_config) != ESP_OK) {
+        printf("PCNT init failed on encoder A pin %d\n", a_pin);
+        return;
+    }
 
     enc_config.pulse_gpio_num = b_pin;
     enc_config.ctrl_gpio_num  = a_pin;
     enc_config.channel        = PCNT_CHANNEL_1;
     enc_config.pos_mode       = PCNT_COUNT_DEC;  //Count Only On Falling-Edges
     enc_config.neg_mode       = PCNT_COUNT_INC;  // Discard Rising-Edge
-    pcnt_unit_config(&enc_config);
+    if (pcnt_unit_config(&enc_config) != ESP_OK) {
+        printf("PCNT init failed on encoder B pin %d\n", b_pin);
+        return;
+    }
 
     pcnt_set_filter_value(PCNT_UNIT_0, 250);  // Filter Runt Pulses
 
@@ -40,10 +78,33 @@ void init_encoder(int a_pin, int b_pin) {
     pcnt_counter_pause(PCNT_UNIT_0);  // Initial PCNT init
     pcnt_counter_clear(PCNT_UNIT_0);
     pcnt_counter_resume(PCNT_UNIT_0);
+    pcnt_ready = true;
 }
 
 int16_t get_encoder() {
+    if (!pcnt_ready) {
+        return 0;
+    }
     int16_t count;
     pcnt_get_counter_value(PCNT_UNIT_0, &count);
     return count;
 }
+#else
+void init_encoder(int a_pin, int b_pin) {
+    encoder_a_pin = a_pin;
+    encoder_b_pin = b_pin;
+
+    pinMode(encoder_a_pin, INPUT_PULLUP);
+    pinMode(encoder_b_pin, INPUT_PULLUP);
+
+    encoder_count = 0;
+    encoder_state = read_encoder_state();
+}
+
+int16_t get_encoder() {
+    uint8_t next_state = read_encoder_state();
+    encoder_count += quadrature_lut[(encoder_state << 2) | next_state];
+    encoder_state = next_state;
+    return encoder_count;
+}
+#endif

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -584,15 +584,17 @@ static bool json_accum_complete() {
     return false;
 }
 
+static bool is_non_json_protocol_message(const char* line) {
+    return line[0] == '<'
+           || strncmp(line, "ok",     2) == 0
+           || strncmp(line, "error:", 6) == 0
+           || strcmp(line, "PING") == 0;
+}
+
 // Returns true if the line was consumed as JSON
 bool receive_plain_json(const char* line) {
-    bool looks_like_new_msg = (line[0] == '<' || line[0] == '['
-                               || strncmp(line, "ok",    2) == 0
-                               || strncmp(line, "error:", 6) == 0
-                               || strcmp(line, "PING") == 0);
-
-    // If a new message type interrupts an in-progress accumulation, discard.
-    if (!_json_accum.empty() && looks_like_new_msg) {
+    // Discard non-JSON messages that interrupt an in-progress accumulation
+    if (!_json_accum.empty() && is_non_json_protocol_message(line)) {
         _json_accum.clear();
         return false;
     }

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -556,7 +556,6 @@ void init_listener() {
 }
 
 void request_file_list(const char* dirname) {
-    dbg_printf("DBG request_file_list: sending $Files/ListGCode=%s\n", dirname);
     send_linef("$Files/ListGCode=%s", dirname);
     // parser.reset();
     parser_needs_reset = true;
@@ -594,7 +593,6 @@ bool receive_plain_json(const char* line) {
 
     // If a new message type interrupts an in-progress accumulation, discard.
     if (!_json_accum.empty() && looks_like_new_msg) {
-        dbg_printf("DBG JSON accum: discarding partial JSON before '%s'\n", line);
         _json_accum.clear();
         return false;
     }
@@ -607,7 +605,6 @@ bool receive_plain_json(const char* line) {
     _json_accum += line;
 
     if (json_accum_complete()) {
-        dbg_printf("DBG JSON accum: complete, len=%d, dispatching\n", (int)_json_accum.size());
         handle_json(_json_accum.c_str());
         _json_accum.clear();
     }
@@ -634,7 +631,6 @@ void parser_parse_line(const char* line) {
 }
 
 extern "C" void handle_json(const char* line) {
-    dbg_printf("DBG handle_json: len=%d first100=%.100s\n", (int)strlen(line), line);
     if (parser_needs_reset) {
         parser_needs_reset = false;
         parser.setListener(pInitialListener);
@@ -684,7 +680,6 @@ void handle_radio_mode(char* command, char* arguments) {
 }
 
 extern "C" void handle_msg(char* command, char* arguments) {
-    dbg_printf("DBG handle_msg: cmd='%s' args='%.80s'\n", command, arguments);
     if (strcmp(command, "Homed") == 0) {
         char c;
         while ((c = *arguments++) != '\0') {

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -556,9 +556,62 @@ void init_listener() {
 }
 
 void request_file_list(const char* dirname) {
+    dbg_printf("DBG request_file_list: sending $Files/ListGCode=%s\n", dirname);
     send_linef("$Files/ListGCode=%s", dirname);
     // parser.reset();
     parser_needs_reset = true;
+}
+
+// ── Plain-JSON receiver ───────────────────────────────────────────────────────
+// Large payloads arrive split across several WebSocket frames; the WS receiver appends '\n' to each, so
+// GrblParserC delivers them as separate lines to handle_other().
+// Accumulate fragments until the outermost JSON object is complete (brace depth -> 0), then dispatch to handle_json().
+
+static std::string _json_accum;
+
+static bool json_accum_complete() {
+    int  depth  = 0;
+    bool in_str = false;
+    bool esc    = false;
+    for (char c : _json_accum) {
+        if (esc)       { esc = false; continue; }
+        if (c == '\\') { esc = true;  continue; }
+        if (c == '"')  { in_str = !in_str; continue; }
+        if (!in_str) {
+            if      (c == '{') ++depth;
+            else if (c == '}') { if (--depth == 0) return true; }
+        }
+    }
+    return false;
+}
+
+// Returns true if the line was consumed as JSON
+bool receive_plain_json(const char* line) {
+    bool looks_like_new_msg = (line[0] == '<' || line[0] == '['
+                               || strncmp(line, "ok",    2) == 0
+                               || strncmp(line, "error:", 6) == 0
+                               || strcmp(line, "PING") == 0);
+
+    // If a new message type interrupts an in-progress accumulation, discard.
+    if (!_json_accum.empty() && looks_like_new_msg) {
+        dbg_printf("DBG JSON accum: discarding partial JSON before '%s'\n", line);
+        _json_accum.clear();
+        return false;
+    }
+
+    // Accept the line if it starts a JSON object or continues one.
+    if (line[0] != '{' && _json_accum.empty()) {
+        return false;
+    }
+
+    _json_accum += line;
+
+    if (json_accum_complete()) {
+        dbg_printf("DBG JSON accum: complete, len=%d, dispatching\n", (int)_json_accum.size());
+        handle_json(_json_accum.c_str());
+        _json_accum.clear();
+    }
+    return true;
 }
 
 void init_file_list() {
@@ -581,6 +634,7 @@ void parser_parse_line(const char* line) {
 }
 
 extern "C" void handle_json(const char* line) {
+    dbg_printf("DBG handle_json: len=%d first100=%.100s\n", (int)strlen(line), line);
     if (parser_needs_reset) {
         parser_needs_reset = false;
         parser.setListener(pInitialListener);
@@ -630,6 +684,7 @@ void handle_radio_mode(char* command, char* arguments) {
 }
 
 extern "C" void handle_msg(char* command, char* arguments) {
+    dbg_printf("DBG handle_msg: cmd='%s' args='%.80s'\n", command, arguments);
     if (strcmp(command, "Homed") == 0) {
         char c;
         while ((c = *arguments++) != '\0') {

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -426,7 +426,7 @@ public:
 } fileLinesListener;
 
 bool is_file(const char* str, const char* filename) {
-    char* s = strstr(str, filename);
+    const char* s = strstr(str, filename);
     return s && strlen(s) == strlen(filename);
 }
 
@@ -684,7 +684,7 @@ extern "C" void handle_msg(char* command, char* arguments) {
         char c;
         while ((c = *arguments++) != '\0') {
             const char* letters = "XYZABCUVW";
-            char*       pos     = strchr(letters, c);
+            const char* pos     = strchr(letters, c);
             if (pos) {
                 set_axis_homed(pos - letters);
             }

--- a/src/FileParser.h
+++ b/src/FileParser.h
@@ -34,3 +34,4 @@ extern std::string wifi_mode, wifi_ip, wifi_connected, wifi_ssid;
 
 void init_listener();
 void init_file_list();
+bool receive_plain_json(const char* line);

--- a/src/FileSelectScene.cpp
+++ b/src/FileSelectScene.cpp
@@ -13,6 +13,10 @@ extern Scene filePreviewScene;
 
 extern Scene& jogScene;
 
+class FileSelectScene;
+static FileSelectScene* pending_file_select_scene = nullptr;
+static void request_current_file_list();
+
 class FileSelectScene : public Scene {
 private:
     int              _selected_file = 0;
@@ -45,6 +49,10 @@ public:
         // a first time only thing, because files are already loaded
         if (prevSelect.size() == 0) {
             prevSelect.push_back(0);
+        }
+        if (fileVector.empty()) {
+            pending_file_select_scene = this;
+            schedule_action(request_current_file_list);
         }
     }
 
@@ -168,6 +176,14 @@ public:
     // clang-format on
 
     void onRightFlick() { activate_scene(&jogScene); }
+
+    void requestCurrentDirectory() {
+        if (dirLevel == 0) {
+            init_file_list();
+        } else {
+            request_file_list(dirName.c_str());
+        }
+    }
 
     void showFiles() {
         // canvas.createSprite(240, 240);
@@ -323,4 +339,12 @@ public:
         showFiles();
     }
 };
+
+static void request_current_file_list() {
+    if (pending_file_select_scene) {
+        pending_file_select_scene->requestCurrentDirectory();
+        pending_file_select_scene = nullptr;
+    }
+}
+
 FileSelectScene fileSelectScene;

--- a/src/FirstBootScene.cpp
+++ b/src/FirstBootScene.cpp
@@ -19,8 +19,8 @@ static constexpr int BTN_W = 160;
 static constexpr int BTN_H = 45;
 static constexpr int BTN_X = (240 - BTN_W) / 2;  // Centered
 
-static constexpr int UART_BTN_Y = 100;
-static constexpr int WIFI_BTN_Y = 160;
+static constexpr int UART_BTN_Y = 105;
+static constexpr int WIFI_BTN_Y = 165;
 
 class FirstBootScene : public Scene {
     uint32_t _entry_ms = 0;
@@ -75,13 +75,13 @@ public:
         drawRect(55, 22, 130, 1, 0, DARKGREY);
 
         // ── Main question ──────────────────────────────────────────────────────
-        wrapped_text("Select connection mode", 70, 200, WHITE, SMALL);
+        wrapped_text("Connection Mode", 80, 200, ORANGE, SMALL);
 
         // ── Buttons (stacked vertically) ────────────────────────────────────────
-        uartBtn.set(BTN_X, UART_BTN_Y, BTN_W, BTN_H, "← UART",
+        uartBtn.set(BTN_X, UART_BTN_Y, BTN_W, BTN_H, "Wired",
                     0x001a4d, 0x4da6ff, 0x4da6ff, [this]() { onUartPress(); });
 
-        wifiBtn.set(BTN_X, WIFI_BTN_Y, BTN_W, BTN_H, "WiFi →",
+        wifiBtn.set(BTN_X, WIFI_BTN_Y, BTN_W, BTN_H, "WiFi",
                     0x003300, 0x66ff66, 0x66ff66, [this]() { onWifiPress(); });
 
         // ── Footer ─────────────────────────────────────────────────────────────

--- a/src/FirstBootScene.cpp
+++ b/src/FirstBootScene.cpp
@@ -2,7 +2,7 @@
 // FirstBootScene.cpp — one-time setup wizard shown on first boot.
 //
 // Asks the user to choose WiFi (WebSocket) or UART (serial cable).
-// Choice is saved to NVS, then the ESP restarts into normal operation.
+// Choice is saved to NVS, then transitions directly to the appropriate scene.
 
 #ifdef ARDUINO
 
@@ -11,7 +11,7 @@
 #    include "Button.h"
 #    include "WiFiConnection.h"
 
-#    include <Esp.h>
+extern void first_boot_complete();
 
 // ─── Geometry ─────────────────────────────────────────────────────────────────
 
@@ -32,14 +32,14 @@ class FirstBootScene : public Scene {
         if (!selectable())
             return;
         wifi_set_uart_mode(false);  // WiFi / WebSocket
-        ESP.restart();
+        first_boot_complete();
     }
 
     void onUartPress() {
         if (!selectable())
             return;
         wifi_set_uart_mode(true);  // UART / serial cable
-        ESP.restart();
+        first_boot_complete();
     }
 
 public:
@@ -54,14 +54,14 @@ public:
         if (!selectable())
             return;
         wifi_set_uart_mode(false);  // WiFi / WebSocket
-        ESP.restart();
+        first_boot_complete();
     }
 
     void onRedButtonPress() override {
         if (!selectable())
             return;
         wifi_set_uart_mode(true);  // UART / serial cable
-        ESP.restart();
+        first_boot_complete();
     }
 
     bool showButtons() override { return false; }

--- a/src/FirstBootScene.cpp
+++ b/src/FirstBootScene.cpp
@@ -12,6 +12,15 @@
 
 #include <Esp.h>
 
+// ─── Geometry ─────────────────────────────────────────────────────────────────
+
+static constexpr int CARD_X = 28;
+static constexpr int CARD_W = 184;
+static constexpr int CARD_H = 66;
+
+static constexpr int WIFI_CARD_Y = 50;
+static constexpr int UART_CARD_Y = 124;
+
 class FirstBootScene : public Scene {
     uint32_t _entry_ms = 0;
 
@@ -22,7 +31,7 @@ public:
 
     void onEntry(void* arg = nullptr) override {
         _entry_ms = millis();
-        reDisplay();
+        set_disconnected_state();  // prevent dispatch_events() redirect to menuScene
     }
 
     void onGreenButtonPress() override {
@@ -45,21 +54,18 @@ public:
         drawMenuTitle("Setup");
         drawRect(55, 22, 130, 1, 0, DARKGREY);
 
-        centered_text("First boot — choose how", 42, LIGHTGREY, TINY);
-        centered_text("FluidDial talks to FluidNC:", 56, LIGHTGREY, TINY);
+        // ── WiFi option ────────────────────────────────────────────────────────
+        drawOutlinedRect(CARD_X, WIFI_CARD_Y, CARD_W, CARD_H, NAVY, GREEN);
+        centered_text("WiFi",               WIFI_CARD_Y + 24, GREEN,     MEDIUM);
+        centered_text("Wireless WebSocket", WIFI_CARD_Y + 46, LIGHTGREY, SMALL);
 
-        // WiFi option — outlined in GREEN to match the Green button
-        drawOutlinedRect(25, 72, 190, 46, NAVY, GREEN);
-        centered_text("WiFi  (Green button)", 90, GREEN, SMALL);
-        centered_text("Wireless via WebSocket", 106, LIGHTGREY, TINY);
+        // ── UART option ────────────────────────────────────────────────────────
+        drawOutlinedRect(CARD_X, UART_CARD_Y, CARD_W, CARD_H, NAVY, RED);
+        centered_text("UART",               UART_CARD_Y + 24, RED,       MEDIUM);
+        centered_text("Wired serial cable", UART_CARD_Y + 46, LIGHTGREY, SMALL);
 
-        // UART option — outlined in RED to match the Red button
-        drawOutlinedRect(25, 124, 190, 46, NAVY, RED);
-        centered_text("UART  (Red button)", 142, RED, SMALL);
-        centered_text("Wired serial cable", 158, LIGHTGREY, TINY);
-
-        centered_text("You can change this later", 182, DARKGREY, TINY);
-        centered_text("in Settings.", 196, DARKGREY, TINY);
+        // ── Footer ─────────────────────────────────────────────────────────────
+        centered_text("Change later in Settings.", 200, DARKGREY, TINY);
 
         drawButtonLegends("UART", "WiFi", "");
         refreshDisplay();

--- a/src/FirstBootScene.cpp
+++ b/src/FirstBootScene.cpp
@@ -19,7 +19,7 @@ static constexpr int BTN_W = 160;
 static constexpr int BTN_H = 45;
 static constexpr int BTN_X = (240 - BTN_W) / 2;  // Centered
 
-static constexpr int UART_BTN_Y = 105;
+static constexpr int UART_BTN_Y = 95;
 static constexpr int WIFI_BTN_Y = 165;
 
 class FirstBootScene : public Scene {
@@ -75,7 +75,7 @@ public:
         drawRect(55, 22, 130, 1, 0, DARKGREY);
 
         // ── Main question ──────────────────────────────────────────────────────
-        wrapped_text("Connection Mode", 80, 200, ORANGE, SMALL);
+        wrapped_text("Connection Mode", 70, 200, ORANGE, SMALL);
 
         // ── Buttons (stacked vertically) ────────────────────────────────────────
         uartBtn.set(BTN_X, UART_BTN_Y, BTN_W, BTN_H, "Wired",

--- a/src/FirstBootScene.cpp
+++ b/src/FirstBootScene.cpp
@@ -1,0 +1,71 @@
+// 2026 - Figamore
+// FirstBootScene.cpp — one-time setup wizard shown on first boot.
+//
+// Asks the user to choose WiFi (WebSocket) or UART (serial cable).
+// Choice is saved to NVS, then the ESP restarts into normal operation.
+
+#ifdef ARDUINO
+
+#include "Scene.h"
+#include "Drawing.h"
+#include "WiFiConnection.h"
+
+#include <Esp.h>
+
+class FirstBootScene : public Scene {
+    uint32_t _entry_ms = 0;
+
+    bool selectable() { return (millis() - _entry_ms) >= 800; }
+
+public:
+    FirstBootScene() : Scene("Setup") {}
+
+    void onEntry(void* arg = nullptr) override {
+        _entry_ms = millis();
+        reDisplay();
+    }
+
+    void onGreenButtonPress() override {
+        if (!selectable()) return;
+        wifi_set_uart_mode(false);  // WiFi / WebSocket
+        ESP.restart();
+    }
+
+    void onRedButtonPress() override {
+        if (!selectable()) return;
+        wifi_set_uart_mode(true);   // UART / serial cable
+        ESP.restart();
+    }
+
+    // Dial is intentionally a no-op — user must pick a transport.
+    void onDialButtonPress() override {}
+
+    void reDisplay() override {
+        background();
+        drawMenuTitle("Setup");
+        drawRect(55, 22, 130, 1, 0, DARKGREY);
+
+        centered_text("First boot — choose how", 42, LIGHTGREY, TINY);
+        centered_text("FluidDial talks to FluidNC:", 56, LIGHTGREY, TINY);
+
+        // WiFi option — outlined in GREEN to match the Green button
+        drawOutlinedRect(25, 72, 190, 46, NAVY, GREEN);
+        centered_text("WiFi  (Green button)", 90, GREEN, SMALL);
+        centered_text("Wireless via WebSocket", 106, LIGHTGREY, TINY);
+
+        // UART option — outlined in RED to match the Red button
+        drawOutlinedRect(25, 124, 190, 46, NAVY, RED);
+        centered_text("UART  (Red button)", 142, RED, SMALL);
+        centered_text("Wired serial cable", 158, LIGHTGREY, TINY);
+
+        centered_text("You can change this later", 182, DARKGREY, TINY);
+        centered_text("in Settings.", 196, DARKGREY, TINY);
+
+        drawButtonLegends("UART", "WiFi", "");
+        refreshDisplay();
+    }
+};
+
+FirstBootScene firstBootScene;
+
+#endif  // ARDUINO

--- a/src/FirstBootScene.cpp
+++ b/src/FirstBootScene.cpp
@@ -64,6 +64,8 @@ public:
         ESP.restart();
     }
 
+    bool showButtons() override { return false; }
+
     // Dial is intentionally a no-op — user must pick a transport.
     void onDialButtonPress() override {}
 
@@ -84,11 +86,6 @@ public:
 
         // ── Footer ─────────────────────────────────────────────────────────────
         centered_text("This can be changed later", 230, DARKGREY, TINY);
-
-        // Hide physical button area (cover with black rectangles)
-        drawRect(0, 270, 80, 50, 0, BLACK);      // Red button area
-        drawRect(80, 270, 80, 50, 0, BLACK);     // Orange button area
-        drawRect(160, 270, 80, 50, 0, BLACK);    // Green button area
  
         refreshDisplay();
     }

--- a/src/FirstBootScene.cpp
+++ b/src/FirstBootScene.cpp
@@ -6,25 +6,41 @@
 
 #ifdef ARDUINO
 
-#include "Scene.h"
-#include "Drawing.h"
-#include "WiFiConnection.h"
+#    include "Scene.h"
+#    include "Drawing.h"
+#    include "Button.h"
+#    include "WiFiConnection.h"
 
-#include <Esp.h>
+#    include <Esp.h>
 
 // ─── Geometry ─────────────────────────────────────────────────────────────────
 
-static constexpr int CARD_X = 28;
-static constexpr int CARD_W = 184;
-static constexpr int CARD_H = 66;
+static constexpr int BTN_W = 160;
+static constexpr int BTN_H = 45;
+static constexpr int BTN_X = (240 - BTN_W) / 2;  // Centered
 
-static constexpr int WIFI_CARD_Y = 50;
-static constexpr int UART_CARD_Y = 124;
+static constexpr int UART_BTN_Y = 100;
+static constexpr int WIFI_BTN_Y = 160;
 
 class FirstBootScene : public Scene {
     uint32_t _entry_ms = 0;
+    Button wifiBtn, uartBtn;
 
     bool selectable() { return (millis() - _entry_ms) >= 800; }
+
+    void onWifiPress() {
+        if (!selectable())
+            return;
+        wifi_set_uart_mode(false);  // WiFi / WebSocket
+        ESP.restart();
+    }
+
+    void onUartPress() {
+        if (!selectable())
+            return;
+        wifi_set_uart_mode(true);  // UART / serial cable
+        ESP.restart();
+    }
 
 public:
     FirstBootScene() : Scene("Setup") {}
@@ -35,14 +51,16 @@ public:
     }
 
     void onGreenButtonPress() override {
-        if (!selectable()) return;
+        if (!selectable())
+            return;
         wifi_set_uart_mode(false);  // WiFi / WebSocket
         ESP.restart();
     }
 
     void onRedButtonPress() override {
-        if (!selectable()) return;
-        wifi_set_uart_mode(true);   // UART / serial cable
+        if (!selectable())
+            return;
+        wifi_set_uart_mode(true);  // UART / serial cable
         ESP.restart();
     }
 
@@ -54,19 +72,30 @@ public:
         drawMenuTitle("Setup");
         drawRect(55, 22, 130, 1, 0, DARKGREY);
 
-        // ── WiFi option ────────────────────────────────────────────────────────
-        drawOutlinedRect(CARD_X, WIFI_CARD_Y, CARD_W, CARD_H, NAVY, GREEN);
-        centered_text("WiFi",               WIFI_CARD_Y + 30, GREEN,     MEDIUM);
+        // ── Main question ──────────────────────────────────────────────────────
+        wrapped_text("Select connection mode", 70, 200, WHITE, SMALL);
 
-        // ── UART option ────────────────────────────────────────────────────────
-        drawOutlinedRect(CARD_X, UART_CARD_Y, CARD_W, CARD_H, NAVY, RED);
-        centered_text("UART",               UART_CARD_Y + 30, RED,       MEDIUM);
+        // ── Buttons (stacked vertically) ────────────────────────────────────────
+        uartBtn.set(BTN_X, UART_BTN_Y, BTN_W, BTN_H, "← UART",
+                    0x001a4d, 0x4da6ff, 0x4da6ff, [this]() { onUartPress(); });
+
+        wifiBtn.set(BTN_X, WIFI_BTN_Y, BTN_W, BTN_H, "WiFi →",
+                    0x003300, 0x66ff66, 0x66ff66, [this]() { onWifiPress(); });
 
         // ── Footer ─────────────────────────────────────────────────────────────
-        centered_text("Change be changed later", 200, DARKGREY, TINY);
+        centered_text("This can be changed later", 230, DARKGREY, TINY);
 
-        drawButtonLegends("UART", "WiFi", "");
+        // Hide physical button area (cover with black rectangles)
+        drawRect(0, 270, 80, 50, 0, BLACK);      // Red button area
+        drawRect(80, 270, 80, 50, 0, BLACK);     // Orange button area
+        drawRect(160, 270, 80, 50, 0, BLACK);    // Green button area
+ 
         refreshDisplay();
+    }
+
+    void onTouchClick() override {
+        wifiBtn.handleTouch(touchX, touchY);
+        uartBtn.handleTouch(touchX, touchY);
     }
 };
 

--- a/src/FirstBootScene.cpp
+++ b/src/FirstBootScene.cpp
@@ -56,16 +56,14 @@ public:
 
         // ── WiFi option ────────────────────────────────────────────────────────
         drawOutlinedRect(CARD_X, WIFI_CARD_Y, CARD_W, CARD_H, NAVY, GREEN);
-        centered_text("WiFi",               WIFI_CARD_Y + 24, GREEN,     MEDIUM);
-        centered_text("Wireless WebSocket", WIFI_CARD_Y + 46, LIGHTGREY, SMALL);
+        centered_text("WiFi",               WIFI_CARD_Y + 30, GREEN,     MEDIUM);
 
         // ── UART option ────────────────────────────────────────────────────────
         drawOutlinedRect(CARD_X, UART_CARD_Y, CARD_W, CARD_H, NAVY, RED);
-        centered_text("UART",               UART_CARD_Y + 24, RED,       MEDIUM);
-        centered_text("Wired serial cable", UART_CARD_Y + 46, LIGHTGREY, SMALL);
+        centered_text("UART",               UART_CARD_Y + 30, RED,       MEDIUM);
 
         // ── Footer ─────────────────────────────────────────────────────────────
-        centered_text("Change later in Settings.", 200, DARKGREY, TINY);
+        centered_text("Change be changed later", 200, DARKGREY, TINY);
 
         drawButtonLegends("UART", "WiFi", "");
         refreshDisplay();

--- a/src/FluidNCModel.cpp
+++ b/src/FluidNCModel.cpp
@@ -12,6 +12,12 @@
 
 extern Scene statusScene;
 
+#if defined(USE_WIFI)
+#    define FLUIDNC_SUPPRESS_STARTUP_SYNC 1
+#else
+#    define FLUIDNC_SUPPRESS_STARTUP_SYNC 0
+#endif
+
 // local copies of status items
 const char*        my_state_string    = "N/C";
 state_t            state              = Idle;
@@ -208,12 +214,16 @@ extern "C" void show_state(const char* state_string) {
     state_t new_state;
     if (decode_state_string(state_string, new_state) && state != new_state) {
         if (state == Disconnected) {
+#if FLUIDNC_SUPPRESS_STARTUP_SYNC
+            dbg_println("WiFi debug: suppressing startup sync burst");
+#else
             fnc_realtime((realtime_cmd_t)0x0c);  // Ctrl-L - echo off
             send_line("$G");                     // Refresh GCode modes
             send_line("$G");                     // Refresh GCode modes
             send_line("$RI=200");
             init_file_list();
             detect_homing_info();
+#endif
         }
         state = new_state;
         if (state == Alarm && lastAlarm == 0) {  // Unknown

--- a/src/FluidNCModel.cpp
+++ b/src/FluidNCModel.cpp
@@ -12,12 +12,6 @@
 
 extern Scene statusScene;
 
-#if defined(USE_WIFI)
-#    define FLUIDNC_SUPPRESS_STARTUP_SYNC 1
-#else
-#    define FLUIDNC_SUPPRESS_STARTUP_SYNC 0
-#endif
-
 // local copies of status items
 const char*        my_state_string    = "N/C";
 state_t            state              = Idle;
@@ -214,9 +208,7 @@ extern "C" void show_state(const char* state_string) {
     state_t new_state;
     if (decode_state_string(state_string, new_state) && state != new_state) {
         if (state == Disconnected) {
-#if FLUIDNC_SUPPRESS_STARTUP_SYNC
-            dbg_println("WiFi debug: suppressing startup sync burst");
-#else
+#ifndef USE_WIFI
             fnc_realtime((realtime_cmd_t)0x0c);  // Ctrl-L - echo off
             send_line("$G");                     // Refresh GCode modes
             send_line("$G");                     // Refresh GCode modes

--- a/src/FluidNCModel.cpp
+++ b/src/FluidNCModel.cpp
@@ -203,19 +203,33 @@ const char* mode_string() {
 state_t previous_state;
 bool    awaiting_alarm = false;
 
+// Called once when status report received after being disconnected.
+// Use schedule_action() to defer execution to dispatch_events() in the main loop where the parser is idle and _report is clean.
+static void connect_init() {
+    dbg_printf("DBG connect_init: starting\n");
+#ifndef USE_WIFI
+    fnc_realtime((realtime_cmd_t)0x0c);  // Ctrl-L - echo off (UART only)
+#endif
+    send_line("$G");
+    dbg_printf("DBG connect_init: sent $G #1\n");
+    send_line("$G");
+    dbg_printf("DBG connect_init: sent $G #2\n");
+    send_line("$RI=200");
+    dbg_printf("DBG connect_init: sent $RI=200\n");
+    init_file_list();
+    dbg_printf("DBG connect_init: sent file list request\n");
+    detect_homing_info();
+    dbg_printf("DBG connect_init: done\n");
+}
+
 extern "C" void show_state(const char* state_string) {
+    dbg_printf("DBG show_state: '%s' (cur=%d)\n", state_string, (int)state);
     previous_state = state;
     state_t new_state;
     if (decode_state_string(state_string, new_state) && state != new_state) {
         if (state == Disconnected) {
-#ifndef USE_WIFI
-            fnc_realtime((realtime_cmd_t)0x0c);  // Ctrl-L - echo off
-            send_line("$G");                     // Refresh GCode modes
-            send_line("$G");                     // Refresh GCode modes
-            send_line("$RI=200");
-            init_file_list();
-            detect_homing_info();
-#endif
+            dbg_printf("DBG show_state: scheduling connect_init\n");
+            schedule_action(connect_init);
         }
         state = new_state;
         if (state == Alarm && lastAlarm == 0) {  // Unknown
@@ -228,6 +242,11 @@ extern "C" void show_state(const char* state_string) {
 }
 
 extern "C" void handle_other(char* line) {
+    // Intercept plain-JSON responses (FluidNC sends {"files":[...]} etc. without the [MSG:JSON:...] wrapper, sometimes split across frames).
+    if (receive_plain_json(line)) {
+        return;
+    }
+    dbg_printf("DBG handle_other: '%s'\n", line);
     if (*line == '$') {
         parse_dollar(line);
         return;
@@ -244,6 +263,7 @@ extern "C" void handle_other(char* line) {
 }
 
 extern "C" void show_error(int error) {
+    dbg_printf("DBG show_error: %d\n", error);
     errorExpire = milliseconds() + 1000;
     lastError   = error;
     current_scene->reDisplay();

--- a/src/FluidNCModel.cpp
+++ b/src/FluidNCModel.cpp
@@ -227,7 +227,6 @@ extern "C" void show_state(const char* state_string) {
         if (state == Alarm && lastAlarm == 0) {  // Unknown
             send_line("$A");                     // Get last alarm
             awaiting_alarm = true;
-            return;
         }
         act_on_state_change();
     }

--- a/src/FluidNCModel.cpp
+++ b/src/FluidNCModel.cpp
@@ -14,7 +14,7 @@ extern Scene statusScene;
 
 // local copies of status items
 const char*        my_state_string    = "N/C";
-state_t            state              = Idle;
+state_t            state              = Disconnected;  // correct: we are disconnected until FluidNC responds
 int                n_axes             = 3;
 pos_t              myAxes[6]          = { 0 };
 bool               myLimitSwitches[6] = { false };

--- a/src/FluidNCModel.cpp
+++ b/src/FluidNCModel.cpp
@@ -206,29 +206,21 @@ bool    awaiting_alarm = false;
 // Called once when status report received after being disconnected.
 // Use schedule_action() to defer execution to dispatch_events() in the main loop where the parser is idle and _report is clean.
 static void connect_init() {
-    dbg_printf("DBG connect_init: starting\n");
 #ifndef USE_WIFI
     fnc_realtime((realtime_cmd_t)0x0c);  // Ctrl-L - echo off (UART only)
 #endif
-    send_line("$G");
-    dbg_printf("DBG connect_init: sent $G #1\n");
-    send_line("$G");
-    dbg_printf("DBG connect_init: sent $G #2\n");
-    send_line("$RI=200");
-    dbg_printf("DBG connect_init: sent $RI=200\n");
-    init_file_list();
-    dbg_printf("DBG connect_init: sent file list request\n");
-    detect_homing_info();
-    dbg_printf("DBG connect_init: done\n");
+    send_line("$G");                     // Refresh GCode modes
+    send_line("$G");                     // Refresh GCode modes
+    send_line("$RI=200");                // Enable auto-reporting every 200 ms
+    init_file_list();                    // Request SD file list
+    detect_homing_info();                // Probe axis homing state
 }
 
 extern "C" void show_state(const char* state_string) {
-    dbg_printf("DBG show_state: '%s' (cur=%d)\n", state_string, (int)state);
     previous_state = state;
     state_t new_state;
     if (decode_state_string(state_string, new_state) && state != new_state) {
         if (state == Disconnected) {
-            dbg_printf("DBG show_state: scheduling connect_init\n");
             schedule_action(connect_init);
         }
         state = new_state;
@@ -246,7 +238,6 @@ extern "C" void handle_other(char* line) {
     if (receive_plain_json(line)) {
         return;
     }
-    dbg_printf("DBG handle_other: '%s'\n", line);
     if (*line == '$') {
         parse_dollar(line);
         return;
@@ -263,7 +254,6 @@ extern "C" void handle_other(char* line) {
 }
 
 extern "C" void show_error(int error) {
-    dbg_printf("DBG show_error: %d\n", error);
     errorExpire = milliseconds() + 1000;
     lastError   = error;
     current_scene->reDisplay();

--- a/src/Hardware2432.cpp
+++ b/src/Hardware2432.cpp
@@ -445,15 +445,17 @@ void init_hardware() {
 int last_locked = -1;
 
 void redrawButtons() {
+    bool show = !current_scene || current_scene->showButtons();
     display.startWrite();
     for (int i = 0; i < n_buttons; i++) {
         Point position = layout->buttonsXY + layout->buttonOffset(i);
-        printf("button position %d,%d\n", position.x, position.y);
         display.fillRect(position.x, position.y, button_w, button_h, BLACK);
-        display.fillCircle(position.x + button_half_wh, position.y + button_half_wh, 28, last_locked == 1 ? DARKGREY : button_colors[i]);
-        if (last_locked != 1) {
-            const char* filename = (i == 0) ? "/red_button.png" : (i == 1) ? "/orange_button.png" : "/green_button.png";
-            display.drawPngFile(LittleFS, filename, position.x + 10, position.y + 10, 60, 60, 0, 0, 0.0f, 0.0f, datum_t::top_left);
+        if (show) {
+            display.fillCircle(position.x + button_half_wh, position.y + button_half_wh, 28, last_locked == 1 ? DARKGREY : button_colors[i]);
+            if (last_locked != 1) {
+                const char* filename = (i == 0) ? "/red_button.png" : (i == 1) ? "/orange_button.png" : "/green_button.png";
+                display.drawPngFile(LittleFS, filename, position.x + 10, position.y + 10, 60, 60, 0, 0, 0.0f, 0.0f, datum_t::top_left);
+            }
         }
     }
     display.endWrite();
@@ -467,6 +469,7 @@ void show_logo() {
 
 void base_display() {
     initButtons();
+    redrawButtons();
 }
 void next_layout(int delta) {
     layout_num += delta;

--- a/src/Hardware2432.cpp
+++ b/src/Hardware2432.cpp
@@ -12,6 +12,7 @@
 #include "Hardware2432.hpp"
 #include "Drawing.h"
 #include "NVS.h"
+#include "Scene.h"
 
 #include <driver/uart.h>
 #include "hal/uart_hal.h"
@@ -466,7 +467,6 @@ void show_logo() {
 
 void base_display() {
     initButtons();
-    redrawButtons();
 }
 void next_layout(int delta) {
     layout_num += delta;
@@ -539,7 +539,7 @@ bool ui_locked(bool redrawButtonsFlag) {
     bool locked = digitalRead(lockout_pin);
     if ((int)locked != last_locked) {
         last_locked = locked;
-        if (redrawButtonsFlag) {
+        if (redrawButtonsFlag && current_scene && current_scene->showButtons()) {
             redrawButtons();
         }
     }

--- a/src/Hardware2432.cpp
+++ b/src/Hardware2432.cpp
@@ -16,6 +16,10 @@
 #include <driver/uart.h>
 #include "hal/uart_hal.h"
 
+#ifdef USE_WIFI
+#    include "WiFiConnection.h"
+#endif
+
 // This pin is connected to a photoresistor that is ostensibly used
 // for ambient light sensing.  It is possible to repurpose it as a UI
 // lock by connecting a normally-open switch between the photoresistor
@@ -419,7 +423,11 @@ void init_hardware() {
     touch.begin(&display);
 
     init_encoder(enc_a, enc_b);
-#ifndef USE_WIFI
+#ifdef USE_WIFI
+    if (wifi_use_uart_mode()) {
+        init_fnc_uart(FNC_UART_NUM, PND_TX_FNC_RX_PIN, PND_RX_FNC_TX_PIN);
+    }
+#else
     init_fnc_uart(FNC_UART_NUM, PND_TX_FNC_RX_PIN, PND_RX_FNC_TX_PIN);
 #endif
 

--- a/src/Hardware2432.cpp
+++ b/src/Hardware2432.cpp
@@ -65,8 +65,6 @@ LGFX_Device  xdisplay;
 LGFX_Device& display = xdisplay;
 
 LGFX_Sprite canvas(&display);
-LGFX_Sprite buttons[3] = { &display, &display, &display };
-LGFX_Sprite locked_button(&display);
 
 uint8_t base_rotation = 2;
 
@@ -379,38 +377,10 @@ void choose_board() {
 #endif
 
 void initButton(int n) {
-    buttons[n].setColorDepth(display.getColorDepth());
-    buttons[n].createSprite(button_w, button_h);
-    buttons[n].fillRect(0, 0, 80, 80, BLACK);
-    const int   radius = 28;
-    const char* filename;
-    int         color;
-    switch (n) {
-        case 0:
-            color    = RED;
-            filename = "/red_button.png";
-            break;
-        case 1:
-            color    = YELLOW;
-            filename = "/orange_button.png";
-            break;
-        case 2:
-            color    = GREEN;
-            filename = "/green_button.png";
-            break;
-    }
-    buttons[n].fillCircle(button_half_wh, button_half_wh, radius, color);
-    // If the image file exists the image will overwrite the circle
-    buttons[n].drawPngFile(LittleFS, filename, 10, 10, 60, 60, 0, 0, 0.0f, 0.0f, datum_t::top_left);
+    (void)n;
 }
 
 void initLockedButton() {
-    locked_button.setColorDepth(display.getColorDepth());
-    locked_button.createSprite(button_w, button_h);
-
-    locked_button.fillRect(0, 0, button_w, button_h, BLACK);
-    const int radius = 28;
-    locked_button.fillCircle(button_half_wh, button_half_wh, radius, DARKGREY);
 }
 
 static void initButtons() {
@@ -449,7 +419,9 @@ void init_hardware() {
     touch.begin(&display);
 
     init_encoder(enc_a, enc_b);
+#ifndef USE_WIFI
     init_fnc_uart(FNC_UART_NUM, PND_TX_FNC_RX_PIN, PND_RX_FNC_TX_PIN);
+#endif
 
     touch.setFlickThresh(10);
 
@@ -468,8 +440,12 @@ void redrawButtons() {
     for (int i = 0; i < n_buttons; i++) {
         Point position = layout->buttonsXY + layout->buttonOffset(i);
         printf("button position %d,%d\n", position.x, position.y);
-        auto& sprite = last_locked == 1 ? locked_button : buttons[i];
-        sprite.pushSprite(position.x, position.y);
+        display.fillRect(position.x, position.y, button_w, button_h, BLACK);
+        display.fillCircle(position.x + button_half_wh, position.y + button_half_wh, 28, last_locked == 1 ? DARKGREY : button_colors[i]);
+        if (last_locked != 1) {
+            const char* filename = (i == 0) ? "/red_button.png" : (i == 1) ? "/orange_button.png" : "/green_button.png";
+            display.drawPngFile(LittleFS, filename, position.x + 10, position.y + 10, 60, 60, 0, 0, 0.0f, 0.0f, datum_t::top_left);
+        }
     }
     display.endWrite();
 }

--- a/src/Hardware2432.cpp
+++ b/src/Hardware2432.cpp
@@ -535,11 +535,13 @@ struct button_debounce_t {
 bool    touch_debounce = false;
 int32_t touch_timeout  = 0;
 
-bool ui_locked() {
+bool ui_locked(bool redrawButtonsFlag) {
     bool locked = digitalRead(lockout_pin);
     if ((int)locked != last_locked) {
         last_locked = locked;
-        redrawButtons();
+        if (redrawButtonsFlag) {
+            redrawButtons();
+        }
     }
     return locked;
 }

--- a/src/HardwareM5Dial.cpp
+++ b/src/HardwareM5Dial.cpp
@@ -7,6 +7,9 @@
 #include "M5GFX.h"
 #include "Drawing.h"
 #include "HardwareM5Dial.hpp"
+#ifdef USE_WIFI
+#    include "WiFiConnection.h"
+#endif
 
 LGFX_Device&       display = M5Dial.Display;
 LGFX_Sprite        canvas(&M5Dial.Display);
@@ -39,7 +42,11 @@ void init_hardware() {
     // at the other end to anything you want and it will still work.
     USBSerial.begin();
 
-#ifndef USE_WIFI
+#ifdef USE_WIFI
+    if (wifi_use_uart_mode()) {
+        init_fnc_uart(FNC_UART_NUM, PND_TX_FNC_RX_PIN, PND_RX_FNC_TX_PIN);
+    }
+#else
     init_fnc_uart(FNC_UART_NUM, PND_TX_FNC_RX_PIN, PND_RX_FNC_TX_PIN);
 #endif
 

--- a/src/HardwareM5Dial.cpp
+++ b/src/HardwareM5Dial.cpp
@@ -135,7 +135,7 @@ void ackBeep() {
     speaker.tone(1800, 50);
 }
 
-bool ui_locked() {
+bool ui_locked(bool redrawButtonsFlag) {
     return false;
 }
 

--- a/src/HardwareM5Dial.cpp
+++ b/src/HardwareM5Dial.cpp
@@ -139,6 +139,10 @@ bool ui_locked(bool redrawButtonsFlag) {
     return false;
 }
 
+int num_layouts = 1;
+int32_t layout_num = 0;
+void redrawButtons() {}
+
 #include <driver/rtc_io.h>
 // The M5 Library is broken with respect to deep sleep on M5 Dial
 // so we have to do it ourselves.  The problem is that the WAKE

--- a/src/HardwareM5Dial.cpp
+++ b/src/HardwareM5Dial.cpp
@@ -39,7 +39,9 @@ void init_hardware() {
     // at the other end to anything you want and it will still work.
     USBSerial.begin();
 
+#ifndef USE_WIFI
     init_fnc_uart(FNC_UART_NUM, PND_TX_FNC_RX_PIN, PND_RX_FNC_TX_PIN);
+#endif
 
     // Setup external GPIOs as buttons
     lgfx::gpio::command(lgfx::gpio::command_mode_input_pullup, RED_BUTTON_PIN);

--- a/src/HelpScene.cpp
+++ b/src/HelpScene.cpp
@@ -14,7 +14,7 @@ public:
         int pos = 20;
         for (; line = *msg, line; ++msg) {
             centered_text(line, pos, WHITE, TINY);
-            pos += 28;
+            pos += 26;
         }
         drawButtonLegends("", "", "Back");
         refreshDisplay();

--- a/src/HomingScene.cpp
+++ b/src/HomingScene.cpp
@@ -36,6 +36,9 @@ void detect_homing_info() {
     homed_axes = 0;
 }
 bool can_home(int i) {
+    if (!homing_cycles[i].known() || !homing_allows[i].known()) {
+        return false;
+    }
     // Cannot home if cycle == 0 and !allow_single_axis
     return homing_cycles[i].get() != 0 || homing_allows[i].get();
 }
@@ -61,6 +64,9 @@ public:
         }
         const char* s = static_cast<const char*>(arg);
         _auto         = s && strcmp(s, "auto") == 0;
+        if (!have_homing_info()) {
+            schedule_action(detect_homing_info);
+        }
     }
 
     void onStateChange(state_t old_state) override {
@@ -159,7 +165,9 @@ public:
                 if (state == Alarm && (strchr(myCtrlPins, 'D') == NULL)) {  // You can reset alarms if door is not active
                     redLabel = "Reset";
                 }
-                if (_axis_to_home == -1) {
+                if (!have_homing_info()) {
+                    orangeLabel = "Loading";
+                } else if (_axis_to_home == -1) {
                     for (int axis = 0; axis < HOMING_N_AXIS; ++axis) {
                         if (can_home(axis)) {
                             if (!grnLabel.length()) {
@@ -184,7 +192,7 @@ public:
                 grnLabel = "Resume";
             }
         }
-        drawButtonLegends(redLabel, grnLabel.c_str(), "Back");
+        drawButtonLegends(redLabel, grnLabel.c_str(), orangeLabel[0] ? orangeLabel : "Back");
 
         refreshDisplay();
     }

--- a/src/MenuScene.cpp
+++ b/src/MenuScene.cpp
@@ -109,6 +109,13 @@ public:
             enableIcons();
         }
     }
+    void onTouchClick() override {
+        if (touchIsCenter() && state == Alarm) {
+            push_scene(&statusScene);
+            return;
+        }
+        PieMenu::onTouchClick();
+    }
     void onStateChange(state_t old_state) override {
         if (state != Disconnected) {
             enableIcons();

--- a/src/MenuScene.cpp
+++ b/src/MenuScene.cpp
@@ -73,7 +73,7 @@ IB controlButton("Macros", &macroMenu, "macrostp.png");
 #ifdef USE_WIFI
 // WiFi scence replaces About button; will reintroduce display orientation later
 extern WiFiSetupScene wifiSetupScene;
-IB setupButton("WiFi", &wifiSetupScene, "abouttp.png");
+IB setupButton("Settings", &wifiSetupScene, "abouttp.png");
 #else
 IB setupButton("About", &aboutScene, "abouttp.png");
 #endif

--- a/src/MenuScene.cpp
+++ b/src/MenuScene.cpp
@@ -4,6 +4,9 @@
 #    include "FileMenu.h"
 #endif
 #include "System.h"
+#ifdef USE_WIFI
+#    include "WiFiSetupScene.h"
+#endif
 
 void noop(void* arg) {}
 
@@ -67,7 +70,13 @@ IB filesButton("Files", &fileSelectScene, "filestp.png");
 #endif
 
 IB controlButton("Macros", &macroMenu, "macrostp.png");
+#ifdef USE_WIFI
+// WiFi scence replaces About button; will reintroduce display orientation later
+extern WiFiSetupScene wifiSetupScene;
+IB setupButton("WiFi", &wifiSetupScene, "abouttp.png");
+#else
 IB setupButton("About", &aboutScene, "abouttp.png");
+#endif
 
 class MenuScene : public PieMenu {
 public:

--- a/src/MenuScene.cpp
+++ b/src/MenuScene.cpp
@@ -72,7 +72,7 @@ IB filesButton("Files", &fileSelectScene, "filestp.png");
 
 IB controlButton("Macros", &macroMenu, "macrostp.png");
 #ifdef USE_WIFI
-// WiFi scence replaces About button; will reintroduce display orientation later
+// WiFi scene replaces About button; will reintroduce display orientation later
 extern WiFiSetupScene wifiSetupScene;
 IB setupButton("Settings", &wifiSetupScene, "abouttp.png");
 #else

--- a/src/MenuScene.cpp
+++ b/src/MenuScene.cpp
@@ -19,6 +19,7 @@ static const char* menu_help_text[] = { "FluidDial",
                                         "Authors: @bdring,@Mitch",
                                         "Bradley,@bDuthieDev,",
                                         "@Design8Studio",
+                                        "WiFi by @Figamore",
                                         NULL };
 
 // PieMenu axisMenu("Axes", buttonRadius);

--- a/src/MultiJogScene.cpp
+++ b/src/MultiJogScene.cpp
@@ -63,14 +63,22 @@ public:
     void drawJogBg() {
         // Recreate jogbg.png with drawing primitives — faster than rendering png which was causing heap issues with WiFi and overall sluggishness :(
         const int cx = 120, cy = 120;
-        const int R  = 114;   // outer circle radius
+        const int R  = 119;   // outer circle radius
         const int ri = 50;    // inner (center circle) radius
         const int hw = 3;     // half-width of separator bands (parallel edges)
-        const uint16_t zone_color = 0x1a4d;  // nicer blue
-        const uint16_t sep_color  = 0x0000;  // black
+        const uint16_t zone_color    = 0x1a4d;  // nicer blue
+        const uint16_t sep_color     = 0x0000;  // black
+        const uint16_t outline_color = 0x8410;
 
         // Fill entire outer disc with blue, then overlay separators + center
         canvas.fillCircle(cx, cy, R, zone_color);
+
+        // Outer circle outline
+        canvas.drawCircle(cx, cy, R, outline_color);
+
+        // Wedges' inner radii outlines:
+        canvas.drawCircle(cx, cy, ri + 1, outline_color);
+
 
         for (int sx = -1; sx <= 1; sx += 2) {
             for (int sy = -1; sy <= 1; sy += 2) {
@@ -85,17 +93,29 @@ public:
                                     cx + ax + px, cy + ay + py, sep_color);
                 canvas.fillTriangle(cx - px, cy - py, cx + ax - px, cy + ay - py,
                                     cx + ax + px, cy + ay + py, sep_color);
+                // Outline the separator edges
+                int oax = (int)(sx * 0.71f * R);
+                int oay = (int)(sy * 0.71f * R);
+                int opx = (int)(-sy * 0.71f * hw);
+                int opy = (int)( sx * 0.71f * hw);
+                canvas.drawLine(cx + opx, cy + opy, cx + oax + opx, cy + oay + opy, outline_color);
+                canvas.drawLine(cx - opx, cy - opy, cx + oax - opx, cy + oay - opy, outline_color);
             }
         }
+
 
         // Center circle void
         canvas.fillCircle(cx, cy, ri, sep_color);
 
+
         // Concentric circle
-        canvas.fillCircle(cx, cy, ri - hw * 2, zone_color);
+        canvas.fillCircle(cx, cy, ri - hw * 1.5, zone_color);
+
+        // Inner circle outline
+        canvas.drawCircle(cx, cy, ri - hw * 1.5, outline_color);
 
         // "Help" hint in center
-        centered_text("Help", cy + 4, 0x0000, MEDIUM);
+        centered_text("Help", cy + 4, BLACK, MEDIUM);
     }
 
     void reDisplay() {

--- a/src/MultiJogScene.cpp
+++ b/src/MultiJogScene.cpp
@@ -63,28 +63,23 @@ public:
     void drawJogBg() {
         // Recreate jogbg.png with drawing primitives — faster than rendering png which was causing heap issues with WiFi and overall sluggishness :(
         const int cx = 120, cy = 120;
-        const int R  = 113;   // outer circle radius
-        const int ri = 40;    // inner (center circle) radius
+        const int R  = 114;   // outer circle radius
+        const int ri = 50;    // inner (center circle) radius
         const int hw = 3;     // half-width of separator bands (parallel edges)
-        const uint16_t zone_color = 0x1928;  // dark navy blue (RGB565)
-        const uint16_t sep_color  = 0x3186;  // dark grey
+        const uint16_t zone_color = 0x1a4d;  // nicer blue
+        const uint16_t sep_color  = 0x0000;  // black
 
         // Fill entire outer disc with blue, then overlay separators + center
         canvas.fillCircle(cx, cy, R, zone_color);
 
-        // Outer rim
-        for (int i = 0; i < 3; i++) {
-            canvas.drawCircle(cx, cy, R - i, sep_color);
-        }
-
         for (int sx = -1; sx <= 1; sx += 2) {
             for (int sy = -1; sy <= 1; sy += 2) {
                 // along the diagonal
-                int ax = (int)(sx * 0.7071f * R);
-                int ay = (int)(sy * 0.7071f * R);
+                int ax = (int)(sx * 0.72f * R);
+                int ay = (int)(sy * 0.72f * R);
                 // perpendicular offset for band width
-                int px = (int)(-sy * 0.7071f * hw);
-                int py = (int)( sx * 0.7071f * hw);
+                int px = (int)(-sy * 0.72f * hw);
+                int py = (int)( sx * 0.72f * hw);
                 // Rectangle corners: center±perp to edge±perp
                 canvas.fillTriangle(cx + px, cy + py, cx - px, cy - py,
                                     cx + ax + px, cy + ay + py, sep_color);
@@ -93,11 +88,14 @@ public:
             }
         }
 
-        // Center circle
+        // Center circle void
         canvas.fillCircle(cx, cy, ri, sep_color);
 
+        // Concentric circle
+        canvas.fillCircle(cx, cy, ri - hw * 2, zone_color);
+
         // "Help" hint in center
-        centered_text("Help", cy + 4, zone_color, TINY);
+        centered_text("Help", cy + 4, 0x0000, MEDIUM);
     }
 
     void reDisplay() {

--- a/src/MultiJogScene.cpp
+++ b/src/MultiJogScene.cpp
@@ -32,6 +32,12 @@ private:
     bool         _continuous    = false;
     LGFX_Sprite* _bg_image      = nullptr;
 
+    // MPG jog rate-limiting: accumulate encoder ticks and send at most one
+    // jog command per MPG_INTERVAL_MS to avoid flooding FluidNC's planner queue.
+    static const uint32_t MPG_INTERVAL_MS = 30;
+    int      _mpg_accum   = 0;
+    uint32_t _last_mpg_ms = 0;
+
 public:
     MultiJogScene() : Scene("Jog", 4, jog_help_text) {}
 
@@ -362,10 +368,25 @@ public:
         cancel_jog();
     }
 
-    void onEncoder(int delta) {
-        if (delta != 0) {
-            start_mpg_jog(delta);
+    void flush_mpg() {
+        if (_mpg_accum == 0) {
+            return;
         }
+        uint32_t now = millis();
+        if ((now - _last_mpg_ms) >= MPG_INTERVAL_MS) {
+            start_mpg_jog(_mpg_accum);
+            _mpg_accum   = 0;
+            _last_mpg_ms = now;
+        }
+    }
+
+    void onEncoder(int delta) {
+        _mpg_accum += delta;
+        flush_mpg();
+    }
+
+    void onPoll() override {
+        flush_mpg();
     }
 
     void onDROChange() {

--- a/src/MultiJogScene.cpp
+++ b/src/MultiJogScene.cpp
@@ -30,8 +30,6 @@ private:
     bool         _cancelling    = false;
     bool         _cancel_held   = false;
     bool         _continuous    = false;
-    LGFX_Sprite* _bg_image      = nullptr;
-
     // MPG jog rate-limiting: accumulate encoder ticks and send at most one
     // jog command per MPG_INTERVAL_MS to avoid flooding FluidNC's planner queue.
     static const uint32_t MPG_INTERVAL_MS = 30;
@@ -62,9 +60,49 @@ public:
         return -1;  // No axis is selected
     }
 
+    void drawJogBg() {
+        // Recreate jogbg.png with drawing primitives — faster than rendering png which was causing heap issues with WiFi and overall sluggishness :(
+        const int cx = 120, cy = 120;
+        const int R  = 113;   // outer circle radius
+        const int ri = 40;    // inner (center circle) radius
+        const int hw = 3;     // half-width of separator bands (parallel edges)
+        const uint16_t zone_color = 0x1928;  // dark navy blue (RGB565)
+        const uint16_t sep_color  = 0x3186;  // dark grey
+
+        // Fill entire outer disc with blue, then overlay separators + center
+        canvas.fillCircle(cx, cy, R, zone_color);
+
+        // Outer rim
+        for (int i = 0; i < 3; i++) {
+            canvas.drawCircle(cx, cy, R - i, sep_color);
+        }
+
+        for (int sx = -1; sx <= 1; sx += 2) {
+            for (int sy = -1; sy <= 1; sy += 2) {
+                // along the diagonal
+                int ax = (int)(sx * 0.7071f * R);
+                int ay = (int)(sy * 0.7071f * R);
+                // perpendicular offset for band width
+                int px = (int)(-sy * 0.7071f * hw);
+                int py = (int)( sx * 0.7071f * hw);
+                // Rectangle corners: center±perp to edge±perp
+                canvas.fillTriangle(cx + px, cy + py, cx - px, cy - py,
+                                    cx + ax + px, cy + ay + py, sep_color);
+                canvas.fillTriangle(cx - px, cy - py, cx + ax - px, cy + ay - py,
+                                    cx + ax + px, cy + ay + py, sep_color);
+            }
+        }
+
+        // Center circle
+        canvas.fillCircle(cx, cy, ri, sep_color);
+
+        // "Help" hint in center
+        centered_text("Help", cy + 4, zone_color, TINY);
+    }
+
     void reDisplay() {
         background();
-        drawBackground(_bg_image);
+        drawJogBg();
         drawMenuTitle(current_scene->name());
         drawStatus();
 
@@ -109,7 +147,6 @@ public:
             zero_axes();
         }
         if (initPrefs()) {
-            _bg_image = createPngBackground("/jogbg.png");
             for (size_t axis = 0; axis < 3; axis++) {
                 getPref("DistanceDigit", axis, &_dist_index[axis]);
             }

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -23,13 +23,14 @@ int touchDeltaY;
 std::vector<Scene*> scene_stack;
 
 void activate_scene(Scene* scene, void* arg) {
+    bool prev_show = !current_scene || current_scene->showButtons();
     if (current_scene) {
         current_scene->onExit();
     }
     current_scene = scene;
     current_scene->onEntry(arg);
     current_scene->reDisplay();
-    if (current_scene->showButtons()) {
+    if (current_scene->showButtons() != prev_show) {
         redrawButtons();
     }
 }

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -29,6 +29,9 @@ void activate_scene(Scene* scene, void* arg) {
     current_scene = scene;
     current_scene->onEntry(arg);
     current_scene->reDisplay();
+    if (current_scene->showButtons()) {
+        redrawButtons();
+    }
 }
 void push_scene(Scene* scene, void* arg) {
     scene_stack.push_back(current_scene);

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -175,6 +175,8 @@ void dispatch_events() {
         dispatch_touch();
     }
 
+    current_scene->onPoll();
+
     if (!fnc_is_connected()) {
         if (state != Disconnected) {
             set_disconnected_state();

--- a/src/Scene.h
+++ b/src/Scene.h
@@ -56,6 +56,7 @@ public:
     virtual void onLimitsChange() {}
     virtual void onMessage(char* command, char* arguments) {}
     virtual void onEncoder(int delta) {}
+    virtual void onPoll() {}
     virtual void reDisplay() {}
     virtual void onEntry(void* arg = nullptr) {}
     virtual void onExit() {}

--- a/src/Scene.h
+++ b/src/Scene.h
@@ -61,6 +61,8 @@ public:
     virtual void onEntry(void* arg = nullptr) {}
     virtual void onExit() {}
 
+    virtual bool showButtons() { return true; }
+
     virtual void onFileLines(int firstline, const std::vector<std::string>& lines) {}
     virtual void onFilesList() {}
 

--- a/src/StatusScene.cpp
+++ b/src/StatusScene.cpp
@@ -29,6 +29,7 @@ public:
         if (arg && strcmp((const char*)arg, "Confirmed") == 0) {
             dbg_printf("StatusScene: sending Ctrl-X soft reset\r\n");
             fnc_realtime(Reset);
+            schedule_action([]() { send_line("$X"); });
         } else {
             dbg_printf("StatusScene: onEntry arg=%s\r\n", arg ? (const char*)arg : "null");
         }

--- a/src/StatusScene.cpp
+++ b/src/StatusScene.cpp
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
 
 #include "Scene.h"
+#include "ConfirmScene.h"
 
 extern Scene menuScene;
 
@@ -22,6 +23,16 @@ public:
     StatusScene() : Scene("Status") {}
 
     void onExit() override {}
+
+    void onEntry(void* arg) override {
+        // Returned from ConfirmScene — execute the deferred soft reset.
+        if (arg && strcmp((const char*)arg, "Confirmed") == 0) {
+            dbg_printf("StatusScene: sending Ctrl-X soft reset\r\n");
+            fnc_realtime(Reset);
+        } else {
+            dbg_printf("StatusScene: onEntry arg=%s\r\n", arg ? (const char*)arg : "null");
+        }
+    }
 
     void onDialButtonPress() {
         if (state == Cycle || state == Hold) {
@@ -61,9 +72,8 @@ public:
         switch (state) {
             case Alarm:
                 if (alarm_is_critical()) {
-                    // Critical alarm that must be hard-cleared with a CTRL-X reset
-                    // since streaming execution of GCode is blocked
-                    fnc_realtime(Reset);
+                    // Soft reset loses work offsets — ask the user to confirm first.
+                    push_scene(&confirmScene, (void*)"Soft Reset?\nOffsets will be lost");
                 } else {
                     // Non-critical alarm that can be soft-cleared
                     send_line("$X");
@@ -80,8 +90,14 @@ public:
 
     bool alarm_is_homing() { return lastAlarm == 14 || (lastAlarm >= 6 && lastAlarm <= 9); }
     bool alarm_is_critical() {
-        // HardLimit or SoftLimit or SpindleControl or HardStop
-        return lastAlarm == 1 || lastAlarm == 2 || lastAlarm == 10 || lastAlarm == 13;
+        switch (lastAlarm) {
+            case 4: case 5:                  // Probe fail
+            case 6: case 7: case 8: case 9: // Homing fail
+            case 14:                         // Unhomed
+                return false;
+            default:
+                return true;
+        }
     }
     void onGreenButtonPress() {
         switch (state) {

--- a/src/System.h
+++ b/src/System.h
@@ -81,6 +81,8 @@ inline int display_short_side() {
 void base_display();
 void set_layout(int n);
 void next_layout(int delta);
+extern int layout_num;
+extern int num_layouts;
 void redrawButtons();
 
 bool ui_locked(bool redrawButtonsFlag = true);

--- a/src/System.h
+++ b/src/System.h
@@ -81,5 +81,6 @@ inline int display_short_side() {
 void base_display();
 void set_layout(int n);
 void next_layout(int delta);
+void redrawButtons();
 
 bool ui_locked(bool redrawButtonsFlag = true);

--- a/src/System.h
+++ b/src/System.h
@@ -11,9 +11,7 @@
 #    include <LittleFS.h>
 constexpr static const int UPDATE_RATE_MS = 30;  // minimum refresh rate in milliseconds
 extern Stream&             debugPort;
-#    ifndef USE_WIFI
 void init_fnc_uart(int uart_num, int tx_pin, int rx_pin);
-#    endif
 #endif  // ARDUINO
 
 #ifdef USE_LOVYANGFX

--- a/src/System.h
+++ b/src/System.h
@@ -35,6 +35,10 @@ void init_fnc_uart(int uart_num, int tx_pin, int rx_pin);
 
 #ifdef USE_M5
 #    include "M5Unified.h"
+#    ifndef ARDUINO
+// Provide Arduino-compatible millis() free function for native (SDL) builds
+static inline uint32_t millis() { return m5gfx::millis(); }
+#    endif
 #endif  // USE_M5
 
 extern LGFX_Device&     display;

--- a/src/System.h
+++ b/src/System.h
@@ -11,7 +11,9 @@
 #    include <LittleFS.h>
 constexpr static const int UPDATE_RATE_MS = 30;  // minimum refresh rate in milliseconds
 extern Stream&             debugPort;
-void                       init_fnc_uart(int uart_num, int tx_pin, int rx_pin);
+#    ifndef USE_WIFI
+void init_fnc_uart(int uart_num, int tx_pin, int rx_pin);
+#    endif
 #endif  // ARDUINO
 
 #ifdef USE_LOVYANGFX

--- a/src/System.h
+++ b/src/System.h
@@ -81,7 +81,7 @@ inline int display_short_side() {
 void base_display();
 void set_layout(int n);
 void next_layout(int delta);
-extern int layout_num;
+extern int32_t layout_num;
 extern int num_layouts;
 void redrawButtons();
 

--- a/src/System.h
+++ b/src/System.h
@@ -82,4 +82,4 @@ void base_display();
 void set_layout(int n);
 void next_layout(int delta);
 
-bool ui_locked();
+bool ui_locked(bool redrawButtonsFlag = true);

--- a/src/SystemArduino.cpp
+++ b/src/SystemArduino.cpp
@@ -13,51 +13,66 @@
 #    include "WiFiConnection.h"
 #endif
 
-#ifndef USE_WIFI
-// ── FOR NOW: UART transport only compiled when USE_WIFI is not defined; will reintroduce later
-#    include <driver/uart.h>
-#    include "hal/uart_hal.h"
+// ── UART transport ─────────────────────────────────────────────────────────────
+// Always compiled so the pendant can operate over UART even in a WiFi build
+// when the user has selected UART mode at runtime.
+#include <driver/uart.h>
+#include "hal/uart_hal.h"
 
 uart_port_t fnc_uart_port;
 
-// We use the ESP-IDF UART driver instead of the Arduino
-// HardwareSerial driver so we can use software (XON/XOFF)
-// flow control.  The ESP-IDF driver supports the ESP32's
-// hardware implementation of XON/XOFF, but Arduino does not.
-
-extern "C" void fnc_putchar(uint8_t c) {
-    uart_write_bytes(fnc_uart_port, (const char*)&c, 1);
-#    ifdef ECHO_FNC_TO_DEBUG
-    dbg_write(c);
-#    endif
-}
-
-void ledcolor(int n) {
+#ifdef LED_DEBUG
+static void ledcolor(int n) {
     digitalWrite(4, !(n & 1));
     digitalWrite(16, !(n & 2));
     digitalWrite(17, !(n & 4));
 }
-extern "C" int fnc_getchar() {
+#endif
+
+static void uart_putchar_impl(uint8_t c) {
+    uart_write_bytes(fnc_uart_port, (const char*)&c, 1);
+#ifdef ECHO_FNC_TO_DEBUG
+    dbg_write(c);
+#endif
+}
+
+static int uart_getchar_impl() {
     char c;
-    int  res = uart_read_bytes(fnc_uart_port, &c, 1, 0);
+    int res = uart_read_bytes(fnc_uart_port, &c, 1, 0);
     if (res == 1) {
-#    ifdef LED_DEBUG
-        if (c == '\r' || c == '\n') {
-            ledcolor(0);
-        } else {
-            ledcolor(c & 7);
-        }
-#    endif
+#ifdef LED_DEBUG
+        if (c == '\r' || c == '\n') { ledcolor(0); }
+        else                        { ledcolor(c & 7); }
+#endif
         update_rx_time();
-#    ifdef ECHO_FNC_TO_DEBUG
+#ifdef ECHO_FNC_TO_DEBUG
         dbg_write(c);
-#    endif
-        return c;
+#endif
+        return (unsigned char)c;
     }
     return -1;
 }
-#endif  // !USE_WIFI
 
+#ifdef USE_WIFI
+// ── Routing: dispatch fnc_putchar/fnc_getchar to WiFi or UART ────────────────
+extern "C" void fnc_putchar(uint8_t c) {
+    if (wifi_use_uart_mode()) uart_putchar_impl(c);
+    else ws_putchar(c);
+}
+extern "C" int fnc_getchar() {
+    if (wifi_use_uart_mode()) return uart_getchar_impl();
+    return ws_getchar();
+}
+#else
+// ── UART-only build ───────────────────────────────────────────────────────────
+extern "C" void fnc_putchar(uint8_t c) { uart_putchar_impl(c); }
+extern "C" int  fnc_getchar()          { return uart_getchar_impl(); }
+#endif
+
+// poll_extra: called by fnc_poll() inside fnc_send_line()'s blocking wait loop.
+// In WiFi mode this MUST drive the WebSocket so that the "ok" response from
+// FluidNC can arrive in _rx_buf — otherwise fnc_send_line() blocks for the
+// full 2000 ms timeout on every second jog command, causing the stall.
 extern "C" void poll_extra() {
 #ifdef USE_WIFI
     wifi_poll();
@@ -89,12 +104,11 @@ void drawPngFile(LGFX_Sprite* sprite, const char* filename, int x, int y) {
 
 // Baud rates up to 10M work
 #ifndef FNC_BAUD
-#    define FNC_BAUD 115200
+#    define FNC_BAUD 1000000
 #endif
 
 extern void init_hardware();
 
-#ifndef USE_WIFI
 void init_fnc_uart(int uart_num, int tx_pin, int rx_pin) {
     fnc_uart_port = (uart_port_t)uart_num;
     int baudrate  = FNC_BAUD;
@@ -125,7 +139,6 @@ void init_fnc_uart(int uart_num, int tx_pin, int rx_pin) {
     uint32_t baud;
     uart_get_baudrate(fnc_uart_port, &baud);
 }
-#endif  // !USE_WIFI
 
 void init_system() {
     init_hardware();
@@ -139,12 +152,13 @@ void init_system() {
     canvas.setColorDepth(8);
     canvas.createSprite(240, 240);  // display.width(), display.height());
 }
-#ifndef USE_WIFI
 void resetFlowControl() {
+#ifdef USE_WIFI
+    if (!wifi_use_uart_mode()) return;  // no-op over WebSocket
+#endif
     fnc_putchar(0x11);
     uart_ll_force_xon(fnc_uart_port);
 }
-#endif  // !USE_WIFI
 
 extern "C" int milliseconds() {
     return millis();

--- a/src/SystemArduino.cpp
+++ b/src/SystemArduino.cpp
@@ -9,6 +9,10 @@
 
 #include <Esp.h>  // ESP.restart()
 
+#ifdef USE_WIFI
+#    include "WiFiConnection.h"
+#endif
+
 #ifndef USE_WIFI
 // ── FOR NOW: UART transport only compiled when USE_WIFI is not defined; will reintroduce later
 #    include <driver/uart.h>
@@ -55,6 +59,9 @@ extern "C" int fnc_getchar() {
 #endif  // !USE_WIFI
 
 extern "C" void poll_extra() {
+#ifdef USE_WIFI
+    wifi_poll();
+#endif
 #ifdef DEBUG_TO_USB
     if (debugPort.available()) {
         char c = debugPort.read();

--- a/src/SystemArduino.cpp
+++ b/src/SystemArduino.cpp
@@ -9,8 +9,10 @@
 
 #include <Esp.h>  // ESP.restart()
 
-#include <driver/uart.h>
-#include "hal/uart_hal.h"
+#ifndef USE_WIFI
+// ── FOR NOW: UART transport only compiled when USE_WIFI is not defined; will reintroduce later
+#    include <driver/uart.h>
+#    include "hal/uart_hal.h"
 
 uart_port_t fnc_uart_port;
 
@@ -21,9 +23,9 @@ uart_port_t fnc_uart_port;
 
 extern "C" void fnc_putchar(uint8_t c) {
     uart_write_bytes(fnc_uart_port, (const char*)&c, 1);
-#ifdef ECHO_FNC_TO_DEBUG
+#    ifdef ECHO_FNC_TO_DEBUG
     dbg_write(c);
-#endif
+#    endif
 }
 
 void ledcolor(int n) {
@@ -35,21 +37,22 @@ extern "C" int fnc_getchar() {
     char c;
     int  res = uart_read_bytes(fnc_uart_port, &c, 1, 0);
     if (res == 1) {
-#ifdef LED_DEBUG
+#    ifdef LED_DEBUG
         if (c == '\r' || c == '\n') {
             ledcolor(0);
         } else {
             ledcolor(c & 7);
         }
-#endif
+#    endif
         update_rx_time();
-#ifdef ECHO_FNC_TO_DEBUG
+#    ifdef ECHO_FNC_TO_DEBUG
         dbg_write(c);
-#endif
+#    endif
         return c;
     }
     return -1;
 }
+#endif  // !USE_WIFI
 
 extern "C" void poll_extra() {
 #ifdef DEBUG_TO_USB
@@ -84,19 +87,20 @@ void drawPngFile(LGFX_Sprite* sprite, const char* filename, int x, int y) {
 
 extern void init_hardware();
 
+#ifndef USE_WIFI
 void init_fnc_uart(int uart_num, int tx_pin, int rx_pin) {
     fnc_uart_port = (uart_port_t)uart_num;
     int baudrate  = FNC_BAUD;
     uart_driver_delete(fnc_uart_port);
     uart_set_pin(fnc_uart_port, (gpio_num_t)tx_pin, (gpio_num_t)rx_pin, -1, -1);
     uart_config_t conf;
-#if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2)
+#    if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2)
     conf.source_clk = UART_SCLK_APB;  // ESP32, ESP32S2
-#endif
-#if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3)
+#    endif
+#    if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3)
     // UART_SCLK_XTAL is independent of the APB frequency
     conf.source_clk = UART_SCLK_XTAL;  // ESP32C3, ESP32S3
-#endif
+#    endif
     conf.baud_rate = baudrate;
 
     conf.data_bits           = UART_DATA_8_BITS;
@@ -114,6 +118,7 @@ void init_fnc_uart(int uart_num, int tx_pin, int rx_pin) {
     uint32_t baud;
     uart_get_baudrate(fnc_uart_port, &baud);
 }
+#endif  // !USE_WIFI
 
 void init_system() {
     init_hardware();
@@ -127,10 +132,12 @@ void init_system() {
     canvas.setColorDepth(8);
     canvas.createSprite(240, 240);  // display.width(), display.height());
 }
+#ifndef USE_WIFI
 void resetFlowControl() {
     fnc_putchar(0x11);
     uart_ll_force_xon(fnc_uart_port);
 }
+#endif  // !USE_WIFI
 
 extern "C" int milliseconds() {
     return millis();

--- a/src/SystemMacOS.cpp
+++ b/src/SystemMacOS.cpp
@@ -279,6 +279,8 @@ nvs_handle_t nvs_init(const char* name) {
     return strdup(dname);
 }
 
-bool ui_locked() {
+bool ui_locked(bool redrawButtonsFlag) {
     return false;
 }
+
+void redrawButtons() {}

--- a/src/SystemMacOS.cpp
+++ b/src/SystemMacOS.cpp
@@ -1,0 +1,284 @@
+// 2026 - Figamore
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+// System interface routines for macOS (native SDL preview build)
+
+#include "stdio.h"
+
+#include "System.h"
+#include "FluidNCModel.h"
+#include "M5GFX.h"
+#include "Drawing.h"
+#include "NVS.h"
+
+#include <fcntl.h>
+#include <termios.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <stdlib.h>
+
+LGFX_Device& display = M5.Display;
+LGFX_Sprite  canvas(&M5.Display);
+
+m5::Speaker_Class& speaker = M5.Speaker;
+m5::Touch_Class&   touch   = M5.Touch;
+
+bool round_display = true;
+
+void system_background() {
+    drawPngFile("PCBackground.png", 0, 0);
+}
+
+void update_events() {
+    lgfx::Panel_sdl::loop();
+    M5.update();
+}
+
+extern "C" int milliseconds() {
+    return m5gfx::millis();
+}
+
+void delay_ms(uint32_t ms) {
+    SDL_Delay(ms);
+}
+
+void drawPngFile(const char* filename, int x, int y) {
+    drawPngFile(&canvas, filename, x, y);
+}
+void drawPngFile(LGFX_Sprite* sprite, const char* filename, int x, int y) {
+    std::string fn("data/");
+    fn += filename;
+    sprite->drawPngFile(fn.c_str(), x, -y, 0, 0, 0, 0, 1.0f, 1.0f, datum_t::middle_center);
+}
+
+static int serial_fd = -1;
+
+static bool open_serial(const char* portname) {
+    serial_fd = open(portname, O_RDWR | O_NOCTTY | O_NONBLOCK);
+    if (serial_fd < 0) {
+        printf("Can't open %s\n", portname);
+        return false;
+    }
+
+    struct termios tty;
+    tcgetattr(serial_fd, &tty);
+    cfsetispeed(&tty, B115200);
+    cfsetospeed(&tty, B115200);
+    tty.c_cflag = (tty.c_cflag & ~CSIZE) | CS8;
+    tty.c_cflag &= ~(PARENB | CSTOPB | CRTSCTS);
+    tty.c_cflag |= CLOCAL | CREAD;
+    tty.c_iflag  = IGNBRK | IGNPAR;
+    tty.c_oflag  = 0;
+    tty.c_lflag  = 0;
+    tty.c_cc[VMIN]  = 0;
+    tty.c_cc[VTIME] = 0;
+    tcsetattr(serial_fd, TCSANOW, &tty);
+    return true;
+}
+
+extern char* comname;
+
+void init_system() {
+    lgfx::Panel_sdl::setup();
+
+    auto cfg = M5.config();
+    M5.begin(cfg);
+
+    if (comname != NULL) {
+        if (!open_serial(comname)) {
+            printf("Running without serial connection\n");
+        }
+    } else {
+        printf("No serial port given — running in preview mode (no FluidNC connection)\n");
+    }
+
+    canvas.createSprite(display.width(), display.height());
+
+    display.clear();
+    speaker.setVolume(255);
+}
+
+Point sprite_offset { 0, 0 };
+
+void show_logo() {}
+void base_display() {
+    display.clear();
+}
+
+void next_layout(int delta) {}
+
+void resetFlowControl() {}
+
+extern "C" void fnc_putchar(uint8_t c) {
+    if (serial_fd >= 0) {
+        write(serial_fd, &c, 1);
+    }
+}
+
+extern "C" int fnc_getchar() {
+    if (serial_fd < 0) {
+        return -1;
+    }
+    char c;
+    int  cnt = (int)read(serial_fd, &c, 1);
+    if (cnt > 0) {
+        update_rx_time();
+        return (unsigned char)c;
+    }
+    return -1;
+}
+
+extern "C" void poll_extra() {}
+
+void dbg_write(uint8_t c) {
+    putchar(c);
+}
+
+void dbg_print(const char* s) {
+    char c;
+    while ((c = *s++) != '\0') {
+        putchar(c);
+    }
+}
+
+static bool outside_of_circle(int& x, int& y) {
+    x -= display.width() / 2;
+    y -= display.height() / 2;
+    int magsq = x * x + y * y;
+    return magsq > (120 * 120);
+}
+
+bool screen_encoder(int x, int y, int& delta) {
+    if (!outside_of_circle(x, y)) {
+        return false;
+    }
+    if (y >= 0) {
+        return false;
+    }
+
+    int tangent = y * 100 / x;
+    if (tangent < 0) {
+        tangent = -tangent;
+    }
+    delta = 4;
+    if (tangent > 172) {
+        delta = 1;
+    } else if (tangent > 100) {
+        delta = 2;
+    } else if (tangent > 58) {
+        delta = 3;
+    }
+    if (x < 0) {
+        delta = -delta;
+    }
+    return true;
+}
+
+bool screen_button_touched(bool pressed, int x, int y, int& button) {
+    if (!outside_of_circle(x, y)) {
+        return false;
+    }
+    if (x <= -90) {
+        button = 0;
+    } else if (x >= 90) {
+        button = 2;
+    } else {
+        button = 1;
+    }
+    return true;
+}
+
+bool switch_button_touched(bool& pressed, int& button) {
+    if (M5.BtnA.wasPressed()) {
+        button  = 0;
+        pressed = true;
+        return true;
+    }
+    if (M5.BtnA.wasReleased()) {
+        button  = 0;
+        pressed = false;
+        return true;
+    }
+    if (M5.BtnB.wasPressed()) {
+        button  = 1;
+        pressed = true;
+        return true;
+    }
+    if (M5.BtnB.wasReleased()) {
+        button  = 1;
+        pressed = false;
+        return true;
+    }
+    if (M5.BtnC.wasPressed()) {
+        button  = 2;
+        pressed = true;
+        return true;
+    }
+    if (M5.BtnC.wasReleased()) {
+        button  = 2;
+        pressed = false;
+        return true;
+    }
+    return false;
+}
+
+void ackBeep() {
+    speaker.tone(1800, 50);
+}
+
+void deep_sleep(int us) {}
+
+int16_t get_encoder() {
+    return 0;
+}
+
+static FILE* prefFile(const char* handle, const char* pname, const char* mode) {
+    static char fname[60];
+    snprintf(fname, 60, "%s/%s", handle, pname);
+    return fopen(fname, mode);
+}
+
+void nvs_get_str(nvs_handle_t handle, const char* name, char* value, size_t* len) {
+    FILE* fd = prefFile(handle, name, "rb");
+    if (fd) {
+        *len = fread(value, 1, *len - 1, fd);
+        fclose(fd);
+    } else {
+        *len = 0;
+    }
+    value[*len] = '\0';
+}
+void nvs_set_str(nvs_handle_t handle, const char* name, const char* value) {
+    FILE* fd = prefFile(handle, name, "wb");
+    if (fd) {
+        fwrite(value, 1, strlen(value), fd);
+        fclose(fd);
+    }
+}
+
+void nvs_get_i32(nvs_handle_t handle, const char* name, int32_t* value) {
+    char   strval[20];
+    size_t len = 20;
+    nvs_get_str(handle, name, strval, &len);
+    if (*strval) {
+        *value = atoi(strval);
+    }
+}
+void nvs_set_i32(nvs_handle_t handle, const char* name, int32_t value) {
+    char valstr[20];
+    snprintf(valstr, 20, "%d", value);
+    nvs_set_str(handle, name, valstr);
+}
+
+nvs_handle_t nvs_init(const char* name) {
+    char dname[50];
+    mkdir("prefs", 0755);
+    snprintf(dname, 50, "prefs/%s", name);
+    mkdir(dname, 0755);
+    return strdup(dname);
+}
+
+bool ui_locked() {
+    return false;
+}

--- a/src/SystemWindows.cpp
+++ b/src/SystemWindows.cpp
@@ -457,6 +457,8 @@ nvs_handle_t nvs_init(const char* name) {
     return strdup(dname);
 }
 
-bool ui_locked() {
+bool ui_locked(bool redrawButtonsFlag) {
     return false;
 }
+
+void redrawButtons() {}

--- a/src/Text.cpp
+++ b/src/Text.cpp
@@ -79,3 +79,65 @@ void auto_text(const std::string& txt, Point xy, int w, int color, fontnum_t fon
     Point dispxy = xy.to_display();
     auto_text(txt, dispxy.x, dispxy.y, w, color, fontnum, datum, tryfonts, trimleft);
 }
+
+void wrapped_text(const char* msg, int y, int w, int color, fontnum_t fontnum) {
+    canvas.setFont(font[fontnum]);
+    
+    // Count lines and find starting y position
+    std::string buffer(msg);
+    int line_count = 1;
+    std::string current_line;
+    
+    size_t pos = 0;
+    while (pos < buffer.length()) {
+        // Skip spaces
+        while (pos < buffer.length() && buffer[pos] == ' ') pos++;
+        if (pos >= buffer.length()) break;
+        
+        // Find next word
+        size_t word_start = pos;
+        while (pos < buffer.length() && buffer[pos] != ' ') pos++;
+        std::string word = buffer.substr(word_start, pos - word_start);
+        
+        // Test if word fits on current line
+        std::string test_line = current_line.empty() ? word : current_line + " " + word;
+        if (canvas.textWidth(test_line.c_str()) > w && !current_line.empty()) {
+            line_count++;
+            current_line = word;
+        } else {
+            current_line = test_line;
+        }
+    }
+    
+    // Draw lines
+    int line_height = 22;
+    int total_height = line_count * line_height;
+    int start_y = y - (total_height / 2);
+    int line_num = 0;
+    
+    current_line.clear();
+    pos = 0;
+    while (pos < buffer.length()) {
+        // Skip spaces
+        while (pos < buffer.length() && buffer[pos] == ' ') pos++;
+        if (pos >= buffer.length()) break;
+        
+        // Find next word
+        size_t word_start = pos;
+        while (pos < buffer.length() && buffer[pos] != ' ') pos++;
+        std::string word = buffer.substr(word_start, pos - word_start);
+        
+        // Test if word fits on current line
+        std::string test_line = current_line.empty() ? word : current_line + " " + word;
+        if (canvas.textWidth(test_line.c_str()) > w && !current_line.empty()) {
+            centered_text(current_line.c_str(), start_y + line_num * line_height, color, fontnum);
+            line_num++;
+            current_line = word;
+        } else {
+            current_line = test_line;
+        }
+    }
+    if (!current_line.empty()) {
+        centered_text(current_line.c_str(), start_y + line_num * line_height, color, fontnum);
+    }
+}

--- a/src/Text.h
+++ b/src/Text.h
@@ -42,3 +42,4 @@ void text(const char* msg, Point xy, int color, fontnum_t fontnum = TINY, int da
 void text(const std::string& msg, Point xy, int color, fontnum_t fontnum = TINY, int datum = middle_center);
 
 void centered_text(const char* msg, int y, int color = WHITE, fontnum_t fontnum = TINY);
+void wrapped_text(const char* msg, int y, int w, int color = WHITE, fontnum_t fontnum = TINY);

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -317,6 +317,9 @@ static const char SETUP_HTML[] = R"HTML(
   button[type=submit]:hover{background:#45a049}
   .note{margin-top:16px;font-size:13px;color:#888;text-align:center}
   .scan-status{font-size:13px;color:#aaa;margin-top:4px;min-height:18px}
+  .eye-btn{padding:10px 12px;background:#2a2a2a;color:#aaa;border:1px solid #555;
+           border-radius:6px;font-size:18px;cursor:pointer;line-height:1}
+  .eye-btn:hover{color:#4CAF50;border-color:#4CAF50}
 </style>
 </head>
 <body>
@@ -325,7 +328,7 @@ static const char SETUP_HTML[] = R"HTML(
 <form method="POST" action="/save">
   <label>WiFi Network Name (SSID)</label>
   <div class="row">
-    <input type="text" name="ssid" id="ssid" placeholder="YourNetworkName" autocomplete="off" required>
+    <input type="text" name="ssid" id="ssid" placeholder="YourNetworkName" autocomplete="off" required value="%SSID_VAL%">
     <button type="button" class="scan-btn" id="scanBtn" onclick="doScan()">Scan</button>
   </div>
   <select id="netList" onchange="pickNet(this)">
@@ -333,10 +336,13 @@ static const char SETUP_HTML[] = R"HTML(
   </select>
   <div id="scanStatus" class="scan-status"></div>
   <label>WiFi Password</label>
-  <input type="password" name="pass" placeholder="Leave blank for open networks">
+  <div class="row">
+    <input type="text" name="pass" id="pass" placeholder="Leave blank for open networks">
+    <button type="button" class="eye-btn" id="eyeBtn" onclick="togglePass()">&#x1F441;</button>
+  </div>
   <label>FluidNC Address (IP or hostname)</label>
   <input type="text" name="ip" placeholder="192.168.1.100 or fluidnc.local"
-         autocomplete="off" required>
+         autocomplete="off" required value="%IP_VAL%">
   <button type="submit">Save &amp; Connect</button>
 </form>
 <p class="note">The pendant will restart and connect automatically.</p>
@@ -368,6 +374,12 @@ function doScan(){
 function pickNet(sel){
   if(sel.value) document.getElementById('ssid').value=sel.value;
 }
+function togglePass(){
+  var p=document.getElementById('pass');
+  var b=document.getElementById('eyeBtn');
+  if(p.type==='text'){p.type='password';b.style.color='#555';}
+  else{p.type='text';b.style.color='#aaa';}
+}
 </script>
 </body>
 </html>
@@ -393,7 +405,11 @@ static const char SAVED_HTML[] = R"HTML(
 // ─── HTTP request handlers ────────────────────────────────────────────────────
 
 static void handleRoot() {
-    httpServer.send(200, "text/html", SETUP_HTML);
+    WiFiConfig cfg = wifi_load_config();
+    String page = SETUP_HTML;
+    page.replace("%SSID_VAL%", cfg.valid ? String(cfg.ssid) : "");
+    page.replace("%IP_VAL%",   cfg.valid ? String(cfg.fluidnc_ip) : "");
+    httpServer.send(200, "text/html", page);
 }
 
 static void handleSave() {

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -37,6 +37,7 @@
 #define TX_BUF_SIZE        512
 #define STATUS_POLL_MS     500         // Send '?' every 500 ms while connected
 #define WIFI_RETRY_DELAY_MS 15000     // Retry WiFi.begin() this long after a failure
+#define DNS_RETRY_DELAY_MS  5000     // Retry hostname resolution this long after a failure
 
 // ─── Globals ─────────────────────────────────────────────────────────────────
 
@@ -76,6 +77,7 @@ static volatile bool _dns_resolving    = false;  // background task is in flight
 static volatile bool _dns_done         = false;  // task finished; read on main task
 static volatile bool _dns_ok           = false;  // resolution succeeded
 static char          _dns_result_str[40] = {};   // resolved IP string (written by task)
+static uint32_t      _dns_retry_at       = 0;    // millis() target for next DNS retry (0 = no retry pending)
 
 static bool is_dotted_decimal(const char* s) {
     for (const char* p = s; *p; p++) {
@@ -592,6 +594,9 @@ void wifi_stop_ap() {
     WiFi.softAPdisconnect(true);
     _ap_mode            = false;
     _wifi_stack_started = false;
+
+    // Re-initiate the STA connection that was torn down by wifi_start_ap_setup().
+    wifi_init();
 }
 
 bool wifi_is_connected() {
@@ -683,6 +688,7 @@ void wifi_init() {
     _wifi_ever_connected     = false;
     _wifi_connect_start_ms   = 0;  // set after WiFi.begin() below
     _handshake_timeout_count = 0;
+    _dns_retry_at            = 0;
 
     static bool _event_registered = false;
     if (!_event_registered) {
@@ -826,6 +832,7 @@ void wifi_poll() {
             ws_begin(_active_cfg.fluidnc_ip);
         } else if (!_dns_resolving) {
             // Hostname — resolve asynchronously; ws_begin() runs when done.
+            _dns_retry_at = 0;  // cancel any pending retry from a prior failure
             start_dns_resolve();
         }
         // WiFi just came up — update badge from "WiFi..." to "WiFi OK".
@@ -853,9 +860,22 @@ void wifi_poll() {
                        _active_cfg.fluidnc_ip, _dns_result_str);
             ws_begin(_dns_result_str);
         } else {
-            dbg_printf("Hostname resolution failed: %s\n", _active_cfg.fluidnc_ip);
+            dbg_printf("Hostname resolution failed: %s — retrying in %d ms\n",
+                       _active_cfg.fluidnc_ip, DNS_RETRY_DELAY_MS);
             _wifi_error_msg = "Host not found";
+            _dns_retry_at   = millis() + DNS_RETRY_DELAY_MS;
         }
+        current_scene->reDisplay();
+    }
+
+    // Retry DNS resolution after a failed attempt (ie: FluidNC may not have
+    // started its mDNS responder yet when both devices boot together).
+    if (_dns_retry_at && !_dns_resolving && !_ws_started && now_connected
+        && millis() >= _dns_retry_at) {
+        _dns_retry_at   = 0;
+        _wifi_error_msg = nullptr;
+        dbg_printf("DNS retry: resolving %s\n", _active_cfg.fluidnc_ip);
+        start_dns_resolve();
         current_scene->reDisplay();
     }
 

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -1,0 +1,411 @@
+// 2026 - Figamore
+// Use of this source code is governed by a GPLv3 license.
+//
+// WiFi / WebSocket transport layer for FluidDial.
+//
+// Provides fnc_putchar() and fnc_getchar() over a WebSocket connection to
+// FluidNC instead of UART.
+
+#ifdef ARDUINO
+
+#include "WiFiConnection.h"
+#include "FluidNCModel.h"
+#include "System.h"
+
+#include <Esp.h>
+#include <WiFi.h>
+#include <WebSocketsClient.h>
+#include <WebServer.h>
+#include <DNSServer.h>
+#include <Preferences.h>
+
+// ─── Configuration ───────────────────────────────────────────────────────────
+
+#define WIFI_AP_SSID       "FluidDial"
+#define WIFI_AP_PASS       ""          // Open AP — no password needed
+#define PREF_NAMESPACE     "fluidwifi"
+#define WS_SUBPROTOCOL     "arduino"
+#define RX_BUF_SIZE        2048
+#define TX_BUF_SIZE        512
+#define PING_INTERVAL_MS   10000       // Application-level PING every 10 s
+#define STATUS_POLL_MS     500         // Send '?' every 500 ms while connected
+
+// ─── Globals ─────────────────────────────────────────────────────────────────
+
+static WebSocketsClient webSocket;
+static WebServer        httpServer(80);
+static DNSServer        dnsServer;
+
+static bool _ap_mode       = false;
+static bool _ws_connected  = false;
+static bool _wifi_was_connected = false;
+
+// Ring buffer for characters received from FluidNC via WebSocket.
+// Written in the WS callback, read by fnc_getchar() (both on the main task).
+static uint8_t _rx_buf[RX_BUF_SIZE];
+static int     _rx_head = 0;
+static int     _rx_tail = 0;
+
+// Line buffer for outgoing text (GCode / $ commands).
+static uint8_t _tx_buf[TX_BUF_SIZE];
+static int     _tx_len = 0;
+
+// Timers.
+static uint32_t _last_ping_ms   = 0;
+static uint32_t _last_status_ms = 0;
+static uint16_t _page_id        = 1234;
+
+static void log_wifi_heap(const char* stage) {
+    dbg_printf("%s free heap: %u\n", stage, ESP.getFreeHeap());
+}
+
+// ─── Ring-buffer helpers ──────────────────────────────────────────────────────
+
+static inline void rx_push(uint8_t c) {
+    int next = (_rx_head + 1) % RX_BUF_SIZE;
+    if (next != _rx_tail) {         // Drop on overflow
+        _rx_buf[_rx_head] = c;
+        _rx_head          = next;
+    }
+}
+
+static inline int rx_pop() {
+    if (_rx_head == _rx_tail) return -1;
+    uint8_t c = _rx_buf[_rx_tail];
+    _rx_tail  = (_rx_tail + 1) % RX_BUF_SIZE;
+    return (unsigned char)c;
+}
+
+// ─── GrblParserC interface ────────────────────────────────────────────────────
+
+// Called by GrblParserC to send one byte to FluidNC.
+extern "C" void fnc_putchar(uint8_t c) {
+    // Skip UART XON/XOFF flow-control bytes (irrelevant over WebSocket).
+    if (c == 0x11 || c == 0x13) return;
+
+    // Extended single-byte realtime commands: Ctrl-X and 0x80–0x9F.
+    if (c == 0x18 || (c >= 0x80 && c <= 0x9F)) {
+        if (_ws_connected) webSocket.sendBIN(&c, 1);
+        return;
+    }
+
+    // ASCII realtime commands ('?', '!', '~') sent *outside* a text line.
+    // GrblParserC calls fnc_putchar() with these as standalone bytes.
+    if (_tx_len == 0 && (c == '?' || c == '!' || c == '~')) {
+        if (_ws_connected) webSocket.sendBIN(&c, 1);
+        return;
+    }
+
+    // Everything else: buffer until '\n', then send as a text frame.
+    _tx_buf[_tx_len++] = c;
+    if (c == '\n' || _tx_len >= TX_BUF_SIZE - 1) {
+        if (_ws_connected) {
+            webSocket.sendTXT((char*)_tx_buf, _tx_len);
+        }
+        _tx_len = 0;
+    }
+}
+
+// Called by GrblParserC to receive one byte from FluidNC.
+extern "C" int fnc_getchar() {
+    return rx_pop();
+}
+
+// ─── WebSocket event handler ──────────────────────────────────────────────────
+
+static void onWsEvent(WStype_t type, uint8_t* payload, size_t length) {
+    switch (type) {
+        case WStype_CONNECTED: {
+            _ws_connected = true;
+            dbg_println("WS: connected to FluidNC");
+
+            // Replay startup log so GrblParserC parses the initial state.
+            webSocket.sendTXT("$SS\n");
+            break;
+        }
+
+        case WStype_DISCONNECTED:
+            _ws_connected = false;
+            dbg_println("WS: disconnected from FluidNC");
+            set_disconnected_state();
+            break;
+
+        case WStype_TEXT:
+        case WStype_BIN: {
+            // Push every received byte into the ring buffer.
+            // GrblParserC's fnc_getchar() will drain it character-by-character.
+            for (size_t i = 0; i < length; i++) {
+                if (payload[i] == '\r') continue;  // Strip CR
+                rx_push(payload[i]);
+            }
+            // Ensure the last line is newline-terminated.
+            if (length > 0 && payload[length - 1] != '\n') {
+                rx_push('\n');
+            }
+            update_rx_time();
+            break;
+        }
+
+        case WStype_PING:
+        case WStype_PONG:
+        case WStype_ERROR:
+        case WStype_FRAGMENT_TEXT_START:
+        case WStype_FRAGMENT_BIN_START:
+        case WStype_FRAGMENT:
+        case WStype_FRAGMENT_FIN:
+            break;
+    }
+}
+
+// ─── Captive portal HTML ──────────────────────────────────────────────────────
+
+static const char SETUP_HTML[] = R"HTML(
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>FluidDial WiFi Setup</title>
+<style>
+  *{box-sizing:border-box}
+  body{font-family:sans-serif;max-width:420px;margin:32px auto;padding:16px;
+       background:#1a1a1a;color:#eee}
+  h2{color:#4CAF50;margin-bottom:4px}
+  p.sub{color:#aaa;font-size:14px;margin-bottom:20px}
+  label{display:block;margin:14px 0 4px;color:#ccc;font-size:14px}
+  input{width:100%;padding:10px;border-radius:6px;border:1px solid #555;
+        background:#2a2a2a;color:#eee;font-size:16px}
+  input:focus{outline:none;border-color:#4CAF50}
+  button{margin-top:24px;width:100%;padding:14px;background:#4CAF50;color:#fff;
+         border:none;border-radius:6px;font-size:18px;cursor:pointer;font-weight:bold}
+  button:hover{background:#45a049}
+  .note{margin-top:16px;font-size:13px;color:#888;text-align:center}
+</style>
+</head>
+<body>
+<h2>FluidDial WiFi Setup</h2>
+<p class="sub">Connect the FluidDial pendant to your WiFi network and FluidNC machine.</p>
+<form method="POST" action="/save">
+  <label>WiFi Network Name (SSID)</label>
+  <input type="text" name="ssid" placeholder="YourNetworkName" autocomplete="off" required>
+  <label>WiFi Password</label>
+  <input type="password" name="pass" placeholder="Leave blank for open networks">
+  <label>FluidNC IP Address</label>
+  <input type="text" name="ip" placeholder="192.168.1.100"
+         pattern="^(\d{1,3}\.){3}\d{1,3}$" required>
+  <button type="submit">Save &amp; Connect</button>
+</form>
+<p class="note">The pendant will restart and connect automatically.</p>
+</body>
+</html>
+)HTML";
+
+static const char SAVED_HTML[] = R"HTML(
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>FluidDial – Saved</title>
+<style>
+  body{font-family:sans-serif;max-width:420px;margin:80px auto;padding:16px;
+       background:#1a1a1a;color:#eee;text-align:center}
+  h2{color:#4CAF50}p{color:#aaa}
+</style></head>
+<body>
+<h2>Settings Saved!</h2>
+<p>FluidDial is restarting and will connect to your network shortly.</p>
+</body>
+</html>
+)HTML";
+
+// ─── HTTP request handlers ────────────────────────────────────────────────────
+
+static void handleRoot() {
+    httpServer.send(200, "text/html", SETUP_HTML);
+}
+
+static void handleSave() {
+    String ssid = httpServer.arg("ssid");
+    String pass = httpServer.arg("pass");
+    String ip   = httpServer.arg("ip");
+
+    if (ssid.length() == 0 || ip.length() == 0) {
+        httpServer.send(400, "text/plain", "SSID and IP are required");
+        return;
+    }
+
+    wifi_save_config(ssid.c_str(), pass.c_str(), ip.c_str());
+    httpServer.send(200, "text/html", SAVED_HTML);
+
+    delay(2000);
+    ESP.restart();
+}
+
+static void handleNotFound() {
+    // Redirect everything to the setup page (captive portal behaviour).
+    httpServer.sendHeader("Location", "http://192.168.4.1/", true);
+    httpServer.send(302, "text/plain", "");
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+void wifi_save_config(const char* ssid, const char* password, const char* ip) {
+    Preferences prefs;
+    prefs.begin(PREF_NAMESPACE, false);
+    prefs.putString("ssid", ssid);
+    prefs.putString("pass", password);
+    prefs.putString("ip",   ip);
+    prefs.end();
+    dbg_printf("WiFi config saved: ssid=%s ip=%s\n", ssid, ip);
+}
+
+WiFiConfig wifi_load_config() {
+    WiFiConfig cfg = {};
+    Preferences prefs;
+    // Open read-write so the namespace is created on first boot, avoiding
+    // the NVS_NOT_FOUND error that occurs with read-only on a fresh device.
+    prefs.begin(PREF_NAMESPACE, false);
+    String ssid = prefs.isKey("ssid") ? prefs.getString("ssid", "") : "";
+    String pass = prefs.isKey("pass") ? prefs.getString("pass", "") : "";
+    String ip   = prefs.isKey("ip")   ? prefs.getString("ip",   "") : "";
+    prefs.end();
+
+    if (ssid.length() > 0 && ip.length() > 0) {
+        strncpy(cfg.ssid,      ssid.c_str(), sizeof(cfg.ssid)      - 1);
+        strncpy(cfg.password,  pass.c_str(), sizeof(cfg.password)  - 1);
+        strncpy(cfg.fluidnc_ip, ip.c_str(), sizeof(cfg.fluidnc_ip) - 1);
+        cfg.valid = true;
+    }
+    return cfg;
+}
+
+void wifi_start_ap_setup() {
+    _ap_mode      = true;
+    _ws_connected = false;
+
+    log_wifi_heap("Starting AP setup");
+    WiFi.disconnect(true);
+    delay(100);
+    WiFi.mode(WIFI_AP);
+    WiFi.softAP(WIFI_AP_SSID, (strlen(WIFI_AP_PASS) ? WIFI_AP_PASS : nullptr));
+
+    IPAddress apIP(192, 168, 4, 1);
+    WiFi.softAPConfig(apIP, apIP, IPAddress(255, 255, 255, 0));
+
+    // DNS: redirect every domain to the AP gateway (captive portal).
+    dnsServer.start(53, "*", apIP);
+
+    httpServer.on("/",      HTTP_GET,  handleRoot);
+    httpServer.on("/save",  HTTP_POST, handleSave);
+    httpServer.onNotFound(handleNotFound);
+    httpServer.begin();
+
+    dbg_printf("AP started — SSID: %s  IP: %s\n",
+               WIFI_AP_SSID, WiFi.softAPIP().toString().c_str());
+}
+
+void wifi_stop_ap_and_restart() {
+    httpServer.stop();
+    dnsServer.stop();
+    WiFi.softAPdisconnect(true);
+    _ap_mode = false;
+    delay(300);
+    ESP.restart();
+}
+
+bool wifi_is_connected() {
+    return WiFi.status() == WL_CONNECTED;
+}
+
+bool websocket_is_connected() {
+    return _ws_connected;
+}
+
+bool wifi_in_ap_mode() {
+    return _ap_mode;
+}
+
+const char* wifi_ap_ssid() {
+    return WIFI_AP_SSID;
+}
+
+const char* wifi_status_str() {
+    if (_ap_mode)               return "AP Setup Mode";
+    if (!wifi_is_connected())   return "Connecting WiFi…";
+    if (!_ws_connected)         return "Connecting FluidNC…";
+    return "Connected";
+}
+
+void wifi_init() {
+    // Random page ID (matches WebUI behaviour).
+    _page_id = (uint16_t)(random(1000, 9999));
+    log_wifi_heap("Before WiFi init");
+
+    WiFiConfig cfg = wifi_load_config();
+
+    if (!cfg.valid) {
+        dbg_println("No WiFi config found — starting AP setup mode");
+        wifi_start_ap_setup();
+        return;
+    }
+
+    dbg_printf("Connecting to WiFi: %s\n", cfg.ssid);
+    WiFi.mode(WIFI_STA);
+    WiFi.setAutoReconnect(true);
+    WiFi.begin(cfg.ssid, cfg.password[0] ? cfg.password : nullptr);
+
+    // Configure WebSocket client — it will connect once WiFi is up.
+    webSocket.begin(cfg.fluidnc_ip, 80, "/", WS_SUBPROTOCOL);
+    webSocket.onEvent(onWsEvent);
+    webSocket.setReconnectInterval(3000);  // retry every 3 s on disconnect
+}
+
+void wifi_poll() {
+    if (_ap_mode) {
+        dnsServer.processNextRequest();
+        httpServer.handleClient();
+        return;
+    }
+
+    // Drive the WebSocket state machine.
+    webSocket.loop();
+
+    // Detect WiFi reconnects so the WebSocket can recover.
+    bool now_connected = wifi_is_connected();
+    if (now_connected && !_wifi_was_connected) {
+        dbg_printf("WiFi connected — IP: %s\n",
+                   WiFi.localIP().toString().c_str());
+    }
+    if (!now_connected && _wifi_was_connected) {
+        _ws_connected = false;
+        set_disconnected_state();
+        dbg_println("WiFi lost");
+    }
+    _wifi_was_connected = now_connected;
+
+    if (!_ws_connected) return;
+
+    uint32_t now = millis();
+
+    // Application-level PING every 10 s (keeps FluidNC page-tracking happy).
+    if (now - _last_ping_ms >= PING_INTERVAL_MS) {
+        _last_ping_ms = now;
+        char ping[32];
+        snprintf(ping, sizeof(ping), "PING:%d\n", _page_id);
+        webSocket.sendTXT(ping);
+    }
+
+    // Explicit status poll every 500 ms.
+    // (FluidNC auto-report via $RI is also set when state transitions from
+    // Disconnected in show_state(), but we poll here as a belt-and-suspenders
+    // measure until the first status arrives.)
+    if (now - _last_status_ms >= STATUS_POLL_MS) {
+        _last_status_ms = now;
+        uint8_t qmark = '?';
+        webSocket.sendBIN(&qmark, 1);
+    }
+}
+
+// Stub: flow control is a no-op over WebSocket.
+void resetFlowControl() {}
+
+#endif  // ARDUINO

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -172,7 +172,6 @@ static void onWsEvent(WStype_t type, uint8_t* payload, size_t length) {
         case WStype_BIN: {
             // Push every received byte into the ring buffer.
             // GrblParserC's fnc_getchar() will drain it character-by-character.
-            dbg_printf("DBG WS RX: type=%d len=%d data='%.80s'\n", (int)type, (int)length, (char*)payload);
             for (size_t i = 0; i < length; i++) {
                 if (payload[i] == '\r') continue;  // Strip CR
                 rx_push(payload[i]);

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -15,6 +15,7 @@
 
 #include <Esp.h>
 #include <WiFi.h>
+#include <ESPmDNS.h>
 #include <WebSocketsClient.h>
 #include <WebServer.h>
 #include <DNSServer.h>
@@ -68,6 +69,52 @@ static int     _tx_len = 0;
 
 // Timers.
 static uint32_t _last_status_ms = 0;
+
+// ─── Async hostname resolution ────────────────────────────────────────────────
+static volatile bool _dns_resolving    = false;  // background task is in flight
+static volatile bool _dns_done         = false;  // task finished; read on main task
+static volatile bool _dns_ok           = false;  // resolution succeeded
+static char          _dns_result_str[40] = {};   // resolved IP string (written by task)
+
+static bool is_dotted_decimal(const char* s) {
+    for (const char* p = s; *p; p++) {
+        if (!((*p >= '0' && *p <= '9') || *p == '.')) return false;
+    }
+    return true;
+}
+
+static void onWsEvent(WStype_t type, uint8_t* payload, size_t length);
+
+static void dnsResolveTask(void* /*param*/) {
+    IPAddress ip;
+    // hostByName() blocks until the mDNS/DNS reply arrives or the stack times
+    // out — running it on a background task keeps the main loop responsive.
+    bool ok = (WiFi.hostByName(_active_cfg.fluidnc_ip, ip) == 1);
+    if (ok) {
+        ip.toString().toCharArray(_dns_result_str, sizeof(_dns_result_str));
+    }
+    _dns_ok        = ok;
+    _dns_done      = true;   // written last — signals main task after result is ready
+    _dns_resolving = false;
+    vTaskDelete(nullptr);
+}
+
+static void start_dns_resolve() {
+    _dns_done      = false;
+    _dns_ok        = false;
+    _dns_resolving = true;
+    dbg_printf("Resolving hostname (async): %s\n", _active_cfg.fluidnc_ip);
+    xTaskCreate(dnsResolveTask, "dns_resolve", 4096, nullptr, 1, nullptr);
+}
+
+static void ws_begin(const char* host) {
+    dbg_printf("Starting WebSocket: ws://%s:%d%s\n", host, FLUIDNC_WS_PORT, FLUIDNC_WS_PATH);
+    webSocket.begin(host, FLUIDNC_WS_PORT, FLUIDNC_WS_PATH, WS_SUBPROTOCOL);
+    webSocket.onEvent(onWsEvent);
+    webSocket.setReconnectInterval(3000);
+    webSocket.enableHeartbeat(15000, 3000, 2);
+    _ws_started = true;
+}
 
 static const char* wifi_status_name(wl_status_t status) {
     switch (status) {
@@ -286,9 +333,9 @@ static const char SETUP_HTML[] = R"HTML(
   <div id="scanStatus" class="scan-status"></div>
   <label>WiFi Password</label>
   <input type="password" name="pass" placeholder="Leave blank for open networks">
-  <label>FluidNC IP Address</label>
-  <input type="text" name="ip" placeholder="192.168.1.100"
-         pattern="^(\d{1,3}\.){3}\d{1,3}$" required>
+  <label>FluidNC Address (IP or hostname)</label>
+  <input type="text" name="ip" placeholder="192.168.1.100 or fluidnc.local"
+         autocomplete="off" required>
   <button type="submit">Save &amp; Connect</button>
 </form>
 <p class="note">The pendant will restart and connect automatically.</p>
@@ -360,7 +407,10 @@ static void handleSave() {
     String cleanIp;
     for (int i = 0; i < (int)ip.length(); i++) {
         char c = ip[i];
-        if ((c >= '0' && c <= '9') || c == '.') cleanIp += c;
+        if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') ||
+            (c >= 'A' && c <= 'Z') || c == '.' || c == '-') {
+            cleanIp += c;
+        }
     }
     ip = cleanIp;
 
@@ -714,12 +764,17 @@ void wifi_poll() {
     if (now_connected && !_wifi_was_connected) {
         dbg_printf("WiFi connected — IP: %s\n",
                    WiFi.localIP().toString().c_str());
-        dbg_printf("Starting WebSocket: ws://%s:%d%s\n", _active_cfg.fluidnc_ip, FLUIDNC_WS_PORT, FLUIDNC_WS_PATH);
-        webSocket.begin(_active_cfg.fluidnc_ip, FLUIDNC_WS_PORT, FLUIDNC_WS_PATH, WS_SUBPROTOCOL);
-        webSocket.onEvent(onWsEvent);
-        webSocket.setReconnectInterval(3000);  // retry every 3 s on disconnect
-        webSocket.enableHeartbeat(15000, 3000, 2);
-        _ws_started = true;
+        // Initialise mDNS so ".local" names resolve via the lwIP mDNS resolver.
+        if (!MDNS.begin("fluiddial")) {
+            dbg_println("mDNS init failed — .local hostnames may not resolve");
+        }
+        if (is_dotted_decimal(_active_cfg.fluidnc_ip)) {
+            // Plain IP address — start WebSocket immediately.
+            ws_begin(_active_cfg.fluidnc_ip);
+        } else if (!_dns_resolving) {
+            // Hostname — resolve asynchronously; ws_begin() runs when done.
+            start_dns_resolve();
+        }
         // WiFi just came up — update badge from "WiFi..." to "WiFi OK".
         current_scene->reDisplay();
     }
@@ -728,11 +783,28 @@ void wifi_poll() {
             webSocket.disconnect();
             _ws_started = false;
         }
+        _dns_done     = false;  // discard any in-flight DNS result
         _ws_connected = false;
         set_disconnected_state();
         dbg_println("WiFi lost");
     }
     _wifi_was_connected = now_connected;
+
+    // Handle async DNS completion (hostname -> IP resolution).
+    // Only act if WiFi is still up and the WebSocket hasn't already started.
+    if (_dns_done && !_ws_started && now_connected) {
+        bool ok = _dns_ok;
+        _dns_done = false;
+        if (ok) {
+            dbg_printf("Hostname resolved: %s -> %s\n",
+                       _active_cfg.fluidnc_ip, _dns_result_str);
+            ws_begin(_dns_result_str);
+        } else {
+            dbg_printf("Hostname resolution failed: %s\n", _active_cfg.fluidnc_ip);
+            _wifi_error_msg = "Host not found";
+        }
+        current_scene->reDisplay();
+    }
 
     if (_ws_started) {
         // Drive the WebSocket state machine only after WiFi is up.

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -454,7 +454,17 @@ void wifi_poll() {
         webSocket.loop();
     }
 
-    if (!_ws_connected) return;
+    // Animate the connecting badge until FluidNC is fully connected.
+    if (!_ws_connected) {
+        static uint32_t _last_anim_ms = 0;
+        uint32_t        now_ms        = millis();
+        if (now_ms - _last_anim_ms >= 400) {
+            _last_anim_ms = now_ms;
+            current_scene->reDisplay();
+        }
+        return;
+    }
+
     // Explicit status poll every 500 ms.
     // (FluidNC auto-report via $RI is also set when state transitions from
     // Disconnected in show_state()

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -605,7 +605,8 @@ void wifi_init() {
     delay(100);
     WiFi.mode(WIFI_STA);
     WiFi.setSleep(false);
-    WiFi.setAutoReconnect(true);
+
+    WiFi.setAutoReconnect(false);
     WiFi.begin(cfg.ssid, cfg.password[0] ? cfg.password : nullptr);
     _wifi_connect_start_ms = millis();
 }
@@ -631,6 +632,9 @@ void wifi_poll() {
             _wifi_retry_at          = 0;
             _wifi_connect_start_ms  = 0;
             _wifi_disconnect_reason = 0;
+            // Re-arm auto-reconnect now that we're up; it was disabled on any
+            // prior failure so drops after a successful session still recover.
+            WiFi.setAutoReconnect(true);
         }
     }
 
@@ -643,34 +647,63 @@ void wifi_poll() {
     }
 
     // Decode the reason code set by the WiFi disconnect event.
+    static const char* const MSG_CHECK_PASS = "Check password";
+    static const char* const MSG_NOT_FOUND  = "Network not found";
+
     if (_wifi_disconnect_reason) {
         uint8_t reason          = _wifi_disconnect_reason;
         _wifi_disconnect_reason = 0;
         dbg_printf("WiFi disconnect reason: %d\n", reason);
 
         if (!_wifi_ever_connected) {
-            if (reason == WIFI_REASON_NO_AP_FOUND) {
-                _wifi_error_msg = "Network not found";
-                _wifi_retry_at  = millis() + WIFI_RETRY_DELAY_MS;
-                current_scene->reDisplay();
-            } else if (reason == WIFI_REASON_AUTH_FAIL    ||
-                       reason == WIFI_REASON_AUTH_EXPIRE  ||
-                       reason == WIFI_REASON_MIC_FAILURE  ||
-                       reason == WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT) {
-                _wifi_error_msg = "Check password";
-                _wifi_retry_at  = millis() + WIFI_RETRY_DELAY_MS;
-                current_scene->reDisplay();
+            const char* new_msg = nullptr;
+            bool        stop_driver = false;
+            bool        allow_retry = false;
+
+            if (reason == WIFI_REASON_AUTH_FAIL          ||
+                reason == WIFI_REASON_AUTH_EXPIRE        ||
+                reason == WIFI_REASON_MIC_FAILURE        ||
+                reason == WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT) {
+                // Auth errors: wrong password can only be fixed by the user —
+                // stop the driver completely and do not schedule any retry.
+                new_msg     = MSG_CHECK_PASS;
+                stop_driver = true;
+                allow_retry = false;
+            } else if (reason == WIFI_REASON_NO_AP_FOUND) {
+                // NO_AP_FOUND fires spuriously during retry rescans even when
+                // the AP is present but rejecting credentials — only show
+                // it if not already identified an auth failure.
+                if (_wifi_error_msg != MSG_CHECK_PASS) {
+                    new_msg     = MSG_NOT_FOUND;
+                    stop_driver = true;   // stop the driver cycle
+                    allow_retry = true;   // network might come back; retry later
+                }
+            }
+
+            if (new_msg) {
+                if (stop_driver) {
+                    WiFi.setAutoReconnect(false);
+                    WiFi.disconnect(false);
+                }
+                bool changed = (_wifi_error_msg != new_msg);
+                _wifi_error_msg = new_msg;
+                // Only arm a retry for not-found; never for wrong password.
+                if (allow_retry && !_wifi_retry_at) {
+                    _wifi_retry_at = millis() + WIFI_RETRY_DELAY_MS;
+                }
+                if (changed) current_scene->reDisplay();
             }
         }
     }
 
-    // Re-issue WiFi.begin() after a failure so the driver tries again.
+    // Re-issue WiFi.begin() after a not-found failure (auth failures never retry).
     if (_wifi_retry_at && millis() >= _wifi_retry_at) {
         _wifi_retry_at         = 0;
-        _wifi_error_msg        = nullptr;   // clear error while retrying
-        _last_wifi_status      = WL_IDLE_STATUS;  // reset so next status change fires
-        _wifi_connect_start_ms = millis();  // reset timeout for the new attempt
+        _wifi_error_msg        = nullptr;
+        _last_wifi_status      = WL_IDLE_STATUS;
+        _wifi_connect_start_ms = millis();
         dbg_printf("WiFi retry: reconnecting to %s\n", _active_cfg.ssid);
+        WiFi.setAutoReconnect(false);  // keep manual control; re-enabled on WL_CONNECTED
         WiFi.disconnect(false);
         delay(100);
         WiFi.begin(_active_cfg.ssid, _active_cfg.password[0] ? _active_cfg.password : nullptr);

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -414,6 +414,14 @@ void wifi_stop_ap_and_restart() {
     ESP.restart();
 }
 
+void wifi_stop_ap() {
+    httpServer.stop();
+    dnsServer.stop();
+    WiFi.softAPdisconnect(true);
+    _ap_mode            = false;
+    _wifi_stack_started = false;
+}
+
 bool wifi_is_connected() {
     return WiFi.status() == WL_CONNECTED;
 }
@@ -461,9 +469,11 @@ void wifi_init() {
     WiFiConfig cfg = wifi_load_config();
 
     if (!cfg.valid) {
-        // No credentials saved yet — don't auto-start AP.
-        // The user must explicitly press "AP Setup" in Settings.
-        dbg_println("No WiFi credentials — press AP Setup in Settings to configure");
+        // No credentials saved yet — auto-start AP so the user can configure
+        // via browser immediately (captive portal at 192.168.4.1).
+        dbg_println("No WiFi credentials — starting AP setup mode automatically");
+        wifi_start_ap_setup();
+        current_scene->reDisplay();  // switch scene from "not configured" to AP view
         return;
     }
 

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -28,7 +28,7 @@
 #define WS_SUBPROTOCOL     "arduino"
 #define FLUIDNC_WS_PORT    80
 #define FLUIDNC_WS_PATH    "/"
-#define HARDCODE_TEST_WIFI 1
+#define HARDCODE_TEST_WIFI 0
 #define TEST_WIFI_SSID     "FluidNC"
 #define TEST_WIFI_PASS     "12345678"
 #define TEST_FLUIDNC_IP    "192.168.0.1"
@@ -42,10 +42,11 @@ static WebSocketsClient webSocket;
 static WebServer        httpServer(80);
 static DNSServer        dnsServer;
 
-static bool _ap_mode       = false;
-static bool _ws_connected  = false;
-static bool _ws_started    = false;
+static bool _ap_mode            = false;
+static bool _ws_connected       = false;
+static bool _ws_started         = false;
 static bool _wifi_was_connected = false;
+static bool _wifi_stack_started = false;  // true only after wifi_init() actually ran
 static WiFiConfig _active_cfg = {};
 static wl_status_t _last_wifi_status = WL_IDLE_STATUS;
 
@@ -110,10 +111,12 @@ static inline int rx_pop() {
     return (unsigned char)c;
 }
 
-// ─── GrblParserC interface ────────────────────────────────────────────────────
+// ─── WebSocket transport primitives ──────────────────────────────────────────
+// These are called by fnc_putchar/fnc_getchar (defined in SystemArduino.cpp)
+// when the active transport is WiFi.
 
-// Called by GrblParserC to send one byte to FluidNC.
-extern "C" void fnc_putchar(uint8_t c) {
+// Send one byte to FluidNC via WebSocket.
+void ws_putchar(uint8_t c) {
     // Skip UART XON/XOFF flow-control bytes (irrelevant over WebSocket).
     if (c == 0x11 || c == 0x13) return;
 
@@ -128,7 +131,6 @@ extern "C" void fnc_putchar(uint8_t c) {
     }
 
     // ASCII realtime commands ('?', '!', '~') sent *outside* a text line.
-    // GrblParserC calls fnc_putchar() with these as standalone bytes.
     if (_tx_len == 0 && (c == '?' || c == '!' || c == '~')) {
         if (_ws_connected) ws_send_bin(&c, 1);
         return;
@@ -144,9 +146,41 @@ extern "C" void fnc_putchar(uint8_t c) {
     }
 }
 
-// Called by GrblParserC to receive one byte from FluidNC.
-extern "C" int fnc_getchar() {
+// Receive one byte from the WebSocket ring buffer (-1 if empty).
+int ws_getchar() {
     return rx_pop();
+}
+
+// ─── Runtime transport mode ───────────────────────────────────────────────────
+
+static int _uart_mode_cached = -1;  // -1 = not yet read from NVS
+
+bool wifi_use_uart_mode() {
+    if (_uart_mode_cached < 0) {
+        Preferences prefs;
+        prefs.begin(PREF_NAMESPACE, false);  // read-write ensures namespace exists
+        _uart_mode_cached = prefs.getBool("uart_mode", false) ? 1 : 0;
+        prefs.end();
+    }
+    return _uart_mode_cached == 1;
+}
+
+void wifi_set_uart_mode(bool uart) {
+    Preferences prefs;
+    prefs.begin(PREF_NAMESPACE, false);
+    prefs.putBool("uart_mode",   uart);
+    prefs.putBool("setup_done",  true);  // clears first-boot flag
+    prefs.end();
+    _uart_mode_cached = uart ? 1 : 0;
+    dbg_printf("Transport mode set to: %s\n", uart ? "UART" : "WiFi");
+}
+
+bool wifi_is_first_boot() {
+    Preferences prefs;
+    prefs.begin(PREF_NAMESPACE, false);
+    bool done = prefs.getBool("setup_done", false);
+    prefs.end();
+    return !done;
 }
 
 // ─── WebSocket event handler ──────────────────────────────────────────────────
@@ -342,9 +376,10 @@ WiFiConfig wifi_load_config() {
 }
 
 void wifi_start_ap_setup() {
-    _ap_mode      = true;
-    _ws_connected = false;
-    _ws_started   = false;
+    _ap_mode            = true;
+    _ws_connected       = false;
+    _ws_started         = false;
+    _wifi_stack_started = true;  // ensure wifi_poll() drives DNS/HTTP server
 
     WiFi.disconnect(true);
     delay(100);
@@ -396,6 +431,7 @@ const char* wifi_ap_ssid() {
 }
 
 const char* wifi_status_str() {
+    if (wifi_use_uart_mode())   return "UART Mode";
     if (_ap_mode)               return "AP Setup Mode";
     if (!wifi_is_connected())   return "Connecting WiFi…";
     if (!_ws_connected)         return "Connecting FluidNC…";
@@ -413,14 +449,25 @@ int wifi_signal_bars() {
 }
 
 void wifi_init() {
-    WiFiConfig cfg = wifi_load_config();
-
-    if (!cfg.valid) {
-        dbg_println("No WiFi config found — starting AP setup mode");
-        wifi_start_ap_setup();
+    if (wifi_use_uart_mode()) {
+        dbg_println("Transport: UART mode — WiFi stack not started");
+        return;
+    }
+    if (wifi_is_first_boot()) {
+        dbg_println("First boot — WiFi deferred until transport is selected");
         return;
     }
 
+    WiFiConfig cfg = wifi_load_config();
+
+    if (!cfg.valid) {
+        // No credentials saved yet — don't auto-start AP.
+        // The user must explicitly press "AP Setup" in Settings.
+        dbg_println("No WiFi credentials — press AP Setup in Settings to configure");
+        return;
+    }
+
+    _wifi_stack_started = true;
     dbg_printf("Connecting to WiFi: %s  FluidNC: %s\n", cfg.ssid, cfg.fluidnc_ip);
     _active_cfg    = cfg;
     _ws_started    = false;
@@ -437,6 +484,9 @@ void wifi_init() {
 }
 
 void wifi_poll() {
+    if (!_wifi_stack_started) return;  // wifi_init() never ran (first boot or UART mode)
+    if (wifi_use_uart_mode()) return;
+
     if (_ap_mode) {
         dnsServer.processNextRequest();
         httpServer.handleClient();
@@ -501,8 +551,5 @@ void wifi_poll() {
         ws_send_bin(&qmark, 1);
     }
 }
-
-// Stub: flow control is a no-op over WebSocket.
-void resetFlowControl() {}
 
 #endif  // ARDUINO

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -33,7 +33,6 @@
 #define TEST_FLUIDNC_IP    "192.168.0.1"
 #define RX_BUF_SIZE        2048
 #define TX_BUF_SIZE        512
-#define FLUIDNC_WS_MINIMAL_STARTUP 1
 #define STATUS_POLL_MS     500         // Send '?' every 500 ms while connected
 
 // ─── Globals ─────────────────────────────────────────────────────────────────
@@ -62,10 +61,6 @@ static int     _tx_len = 0;
 // Timers.
 static uint32_t _last_status_ms = 0;
 
-static void log_wifi_heap(const char* stage) {
-    dbg_printf("%s free heap: %u\n", stage, ESP.getFreeHeap());
-}
-
 static const char* wifi_status_name(wl_status_t status) {
     switch (status) {
         case WL_NO_SHIELD:
@@ -90,16 +85,10 @@ static const char* wifi_status_name(wl_status_t status) {
 }
 
 static bool ws_send_text(uint8_t* payload, size_t length) {
-    dbg_printf("WS TX text len=%u\n", (unsigned)length);
     return webSocket.sendTXT(payload, length);
 }
 
 static bool ws_send_bin(const uint8_t* payload, size_t length) {
-    if (length > 0) {
-        dbg_printf("WS TX bin len=%u first=0x%02X\n", (unsigned)length, payload[0]);
-    } else {
-        dbg_printf("WS TX bin len=0\n");
-    }
     return webSocket.sendBIN(payload, length);
 }
 
@@ -163,13 +152,6 @@ static void onWsEvent(WStype_t type, uint8_t* payload, size_t length) {
             _ws_connected = true;
             _last_status_ms = 0;
             dbg_printf("WS: connected to FluidNC at ws://%s:%d%s\n", _active_cfg.fluidnc_ip, FLUIDNC_WS_PORT, FLUIDNC_WS_PATH);
-
-#if !FLUIDNC_WS_MINIMAL_STARTUP
-            // Replay startup log so GrblParserC parses the initial state.
-            ws_send_text((uint8_t*)"$SS\n", 4);
-#else
-            dbg_println("WS: minimal startup mode enabled; suppressing automatic startup writes");
-#endif
             break;
         }
 
@@ -181,7 +163,6 @@ static void onWsEvent(WStype_t type, uint8_t* payload, size_t length) {
 
         case WStype_TEXT:
         case WStype_BIN: {
-            dbg_printf("WS RX %s len=%u\n", type == WStype_TEXT ? "text" : "bin", (unsigned)length);
             // Push every received byte into the ring buffer.
             // GrblParserC's fnc_getchar() will drain it character-by-character.
             for (size_t i = 0; i < length; i++) {
@@ -349,7 +330,6 @@ void wifi_start_ap_setup() {
     _ws_connected = false;
     _ws_started   = false;
 
-    log_wifi_heap("Starting AP setup");
     WiFi.disconnect(true);
     delay(100);
     WiFi.mode(WIFI_AP);
@@ -407,8 +387,6 @@ const char* wifi_status_str() {
 }
 
 void wifi_init() {
-    log_wifi_heap("Before WiFi init");
-
     WiFiConfig cfg = wifi_load_config();
 
     if (!cfg.valid) {
@@ -472,21 +450,15 @@ void wifi_poll() {
     }
 
     if (!_ws_connected) return;
-
-    uint32_t now = millis();
-
-#if !FLUIDNC_WS_MINIMAL_STARTUP
     // Explicit status poll every 500 ms.
     // (FluidNC auto-report via $RI is also set when state transitions from
     // Disconnected in show_state()
+    uint32_t now = millis();
     if (now - _last_status_ms >= STATUS_POLL_MS) {
         _last_status_ms = now;
         uint8_t qmark = '?';
         ws_send_bin(&qmark, 1);
     }
-#else
-    (void)now;
-#endif
 }
 
 // Stub: flow control is a no-op over WebSocket.

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -441,9 +441,14 @@ const char* wifi_ap_ssid() {
 const char* wifi_status_str() {
     if (wifi_use_uart_mode())   return "UART Mode";
     if (_ap_mode)               return "AP Setup Mode";
-    if (!wifi_is_connected())   return "Connecting WiFi…";
-    if (!_ws_connected)         return "Connecting FluidNC…";
+    if (!wifi_is_connected())   return "Connecting to WiFi";
+    if (!_ws_connected)         return "Connecting to FluidNC";
     return "Connected";
+}
+
+const bool wifi_not_ready() {
+
+    return (!wifi_is_connected() || !_ws_connected);
 }
 
 int wifi_signal_bars() {

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -404,11 +404,28 @@ static const char SAVED_HTML[] = R"HTML(
 
 // ─── HTTP request handlers ────────────────────────────────────────────────────
 
+static String htmlEscape(const String& input) {
+    String escaped;
+    escaped.reserve(input.length());
+    for (size_t i = 0; i < input.length(); ++i) {
+        char c = input[i];
+        switch (c) {
+            case '&':  escaped += F("&amp;");  break;
+            case '<':  escaped += F("&lt;");   break;
+            case '>':  escaped += F("&gt;");   break;
+            case '"':  escaped += F("&quot;"); break;
+            case '\'': escaped += F("&#39;");  break;
+            default:   escaped += c;           break;
+        }
+    }
+    return escaped;
+}
+
 static void handleRoot() {
     WiFiConfig cfg = wifi_load_config();
     String page = SETUP_HTML;
-    page.replace("%SSID_VAL%", cfg.valid ? String(cfg.ssid) : "");
-    page.replace("%IP_VAL%",   cfg.valid ? String(cfg.fluidnc_ip) : "");
+    page.replace("%SSID_VAL%", cfg.valid ? htmlEscape(String(cfg.ssid)) : "");
+    page.replace("%IP_VAL%",   cfg.valid ? htmlEscape(String(cfg.fluidnc_ip)) : "");
     httpServer.send(200, "text/html", page);
 }
 

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -248,13 +248,21 @@ static const char SETUP_HTML[] = R"HTML(
   h2{color:#4CAF50;margin-bottom:4px}
   p.sub{color:#aaa;font-size:14px;margin-bottom:20px}
   label{display:block;margin:14px 0 4px;color:#ccc;font-size:14px}
-  input{width:100%;padding:10px;border-radius:6px;border:1px solid #555;
+  input,select{width:100%;padding:10px;border-radius:6px;border:1px solid #555;
         background:#2a2a2a;color:#eee;font-size:16px}
-  input:focus{outline:none;border-color:#4CAF50}
-  button{margin-top:24px;width:100%;padding:14px;background:#4CAF50;color:#fff;
+  input:focus,select:focus{outline:none;border-color:#4CAF50}
+  .row{display:flex;gap:8px}
+  .row input{flex:1}
+  .scan-btn{padding:10px 14px;background:#2a2a2a;color:#4CAF50;border:1px solid #4CAF50;
+            border-radius:6px;font-size:14px;cursor:pointer;white-space:nowrap;font-weight:bold}
+  .scan-btn:hover{background:#1e3d1e}
+  .scan-btn:disabled{color:#555;border-color:#555;cursor:default}
+  #netList{display:none;margin-top:6px}
+  button[type=submit]{margin-top:24px;width:100%;padding:14px;background:#4CAF50;color:#fff;
          border:none;border-radius:6px;font-size:18px;cursor:pointer;font-weight:bold}
-  button:hover{background:#45a049}
+  button[type=submit]:hover{background:#45a049}
   .note{margin-top:16px;font-size:13px;color:#888;text-align:center}
+  .scan-status{font-size:13px;color:#aaa;margin-top:4px;min-height:18px}
 </style>
 </head>
 <body>
@@ -262,7 +270,14 @@ static const char SETUP_HTML[] = R"HTML(
 <p class="sub">Connect the FluidDial pendant to your WiFi network and FluidNC machine.</p>
 <form method="POST" action="/save">
   <label>WiFi Network Name (SSID)</label>
-  <input type="text" name="ssid" placeholder="YourNetworkName" autocomplete="off" required>
+  <div class="row">
+    <input type="text" name="ssid" id="ssid" placeholder="YourNetworkName" autocomplete="off" required>
+    <button type="button" class="scan-btn" id="scanBtn" onclick="doScan()">Scan</button>
+  </div>
+  <select id="netList" onchange="pickNet(this)">
+    <option value="">-- select a network --</option>
+  </select>
+  <div id="scanStatus" class="scan-status"></div>
   <label>WiFi Password</label>
   <input type="password" name="pass" placeholder="Leave blank for open networks">
   <label>FluidNC IP Address</label>
@@ -271,6 +286,35 @@ static const char SETUP_HTML[] = R"HTML(
   <button type="submit">Save &amp; Connect</button>
 </form>
 <p class="note">The pendant will restart and connect automatically.</p>
+<script>
+function doScan(){
+  var btn=document.getElementById('scanBtn');
+  var lst=document.getElementById('netList');
+  var st=document.getElementById('scanStatus');
+  btn.disabled=true; btn.textContent='Scanning...';
+  st.textContent='Scanning for networks, please wait...';
+  lst.style.display='none';
+  fetch('/scan').then(function(r){return r.json();}).then(function(nets){
+    lst.innerHTML='<option value="">-- select a network --</option>';
+    nets.sort(function(a,b){return b.rssi-a.rssi;});
+    nets.forEach(function(n){
+      var o=document.createElement('option');
+      o.value=n.ssid;
+      o.textContent=n.ssid+(n.secure?' [secured]':'')+'  ('+n.rssi+' dBm)';
+      lst.appendChild(o);
+    });
+    lst.style.display='block';
+    st.textContent=nets.length+' network'+(nets.length!==1?'s':'')+' found.';
+    btn.disabled=false; btn.textContent='Scan';
+  }).catch(function(){
+    st.textContent='Scan failed. Try again.';
+    btn.disabled=false; btn.textContent='Scan';
+  });
+}
+function pickNet(sel){
+  if(sel.value) document.getElementById('ssid').value=sel.value;
+}
+</script>
 </body>
 </html>
 )HTML";
@@ -324,6 +368,36 @@ static void handleSave() {
 
     delay(2000);
     ESP.restart();
+}
+
+static void handleScan() {
+    int n = WiFi.scanNetworks(false, false);  // blocking, no hidden networks
+
+    String json = "[";
+    for (int i = 0; i < n && i < 32; i++) {
+        if (i > 0) json += ",";
+        // Escape backslashes and double-quotes to produce valid JSON.
+        String ssid = WiFi.SSID(i);
+        String safe;
+        safe.reserve(ssid.length());
+        for (int j = 0; j < (int)ssid.length(); j++) {
+            char c = ssid[j];
+            if (c == '\\' || c == '"') safe += '\\';
+            if (c >= 0x20) safe += c;  // drop control characters
+        }
+        json += "{\"ssid\":\"";
+        json += safe;
+        json += "\",\"rssi\":";
+        json += String(WiFi.RSSI(i));
+        json += ",\"secure\":";
+        json += (WiFi.encryptionType(i) != WIFI_AUTH_OPEN) ? "true" : "false";
+        json += "}";
+    }
+    json += "]";
+    WiFi.scanDelete();
+
+    httpServer.sendHeader("Cache-Control", "no-cache");
+    httpServer.send(200, "application/json", json);
 }
 
 static void handleNotFound() {
@@ -383,7 +457,9 @@ void wifi_start_ap_setup() {
 
     WiFi.disconnect(true);
     delay(100);
-    WiFi.mode(WIFI_AP);
+    // WIFI_AP_STA keeps the STA interface active so WiFi.scanNetworks() works
+    // while the AP is running (pure WIFI_AP disables the STA scan engine).
+    WiFi.mode(WIFI_AP_STA);
     WiFi.softAP(WIFI_AP_SSID, (strlen(WIFI_AP_PASS) ? WIFI_AP_PASS : nullptr));
 
     IPAddress apIP(192, 168, 4, 1);
@@ -397,6 +473,7 @@ void wifi_start_ap_setup() {
     httpServer.on("/hotspot-detect.html", HTTP_GET, handleRoot);
     httpServer.on("/ncsi.txt", HTTP_GET, handleRoot);
     httpServer.on("/fwlink", HTTP_GET, handleRoot);
+    httpServer.on("/scan",  HTTP_GET,  handleScan);
     httpServer.on("/save",  HTTP_POST, handleSave);
     httpServer.onNotFound(handleNotFound);
     httpServer.begin();

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -35,6 +35,7 @@
 #define RX_BUF_SIZE        2048
 #define TX_BUF_SIZE        512
 #define STATUS_POLL_MS     500         // Send '?' every 500 ms while connected
+#define WIFI_RETRY_DELAY_MS 15000     // Retry WiFi.begin() this long after a failure
 
 // ─── Globals ─────────────────────────────────────────────────────────────────
 
@@ -48,7 +49,12 @@ static bool _ws_started         = false;
 static bool _wifi_was_connected = false;
 static bool _wifi_stack_started = false;  // true only after wifi_init() actually ran
 static WiFiConfig _active_cfg = {};
-static wl_status_t _last_wifi_status = WL_IDLE_STATUS;
+static wl_status_t      _last_wifi_status        = WL_IDLE_STATUS;
+static const char*      _wifi_error_msg           = nullptr;  // human-readable failure, cleared on success
+static uint32_t         _wifi_retry_at            = 0;        // millis() target for the next WiFi.begin() retry
+static volatile uint8_t _wifi_disconnect_reason   = 0;        // set by WiFi event, read in wifi_poll()
+static bool             _wifi_ever_connected      = false;    // true once WL_CONNECTED seen; blocks false-positive on drops
+static uint32_t         _wifi_connect_start_ms    = 0;        // millis() when WiFi.begin() was last issued
 
 // Ring buffer for characters received from FluidNC via WebSocket.
 // Written in the WS callback, read by fnc_getchar() (both on the main task).
@@ -528,6 +534,15 @@ const bool wifi_not_ready() {
     return (!wifi_is_connected() || !_ws_connected);
 }
 
+const char* wifi_last_error() {
+    return _wifi_error_msg;
+}
+
+// Returns the config that was loaded at wifi_init() time — no NVS read.
+WiFiConfig wifi_active_config() {
+    return _active_cfg;
+}
+
 int wifi_signal_bars() {
     if (!wifi_is_connected()) return 0;
     int rssi = WiFi.RSSI();
@@ -536,6 +551,13 @@ int wifi_signal_bars() {
     if (rssi >= -75) return 2;   // Fair
     if (rssi >= -85) return 1;   // Weak
     return 0;                    // Very weak
+}
+
+// ─── WiFi event handler ───────────────────────────────────────────────────────
+// Called from the WiFi task — only set a flag; UI work happens in wifi_poll().
+
+static void onWiFiDisconnect(WiFiEvent_t event, WiFiEventInfo_t info) {
+    _wifi_disconnect_reason = info.wifi_sta_disconnected.reason;
 }
 
 void wifi_init() {
@@ -561,11 +583,23 @@ void wifi_init() {
 
     _wifi_stack_started = true;
     dbg_printf("Connecting to WiFi: %s  FluidNC: %s\n", cfg.ssid, cfg.fluidnc_ip);
-    _active_cfg    = cfg;
-    _ws_started    = false;
-    _ws_connected  = false;
-    _wifi_was_connected = false;
-    _last_wifi_status = WL_IDLE_STATUS;
+    _active_cfg              = cfg;
+    _ws_started              = false;
+    _ws_connected            = false;
+    _wifi_was_connected      = false;
+    _last_wifi_status        = WL_IDLE_STATUS;
+    _wifi_error_msg          = nullptr;
+    _wifi_retry_at           = 0;
+    _wifi_disconnect_reason  = 0;
+    _wifi_ever_connected     = false;
+    _wifi_connect_start_ms   = 0;  // set after WiFi.begin() below
+
+    static bool _event_registered = false;
+    if (!_event_registered) {
+        WiFi.onEvent(onWiFiDisconnect, ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
+        _event_registered = true;
+    }
+
     WiFi.persistent(false);
     WiFi.disconnect(true);  // Ensure clean driver state (especially after AP mode).
     delay(100);
@@ -573,6 +607,7 @@ void wifi_init() {
     WiFi.setSleep(false);
     WiFi.setAutoReconnect(true);
     WiFi.begin(cfg.ssid, cfg.password[0] ? cfg.password : nullptr);
+    _wifi_connect_start_ms = millis();
 }
 
 void wifi_poll() {
@@ -589,6 +624,56 @@ void wifi_poll() {
     if (wifi_status != _last_wifi_status) {
         dbg_printf("WiFi status: %s (%d)\n", wifi_status_name(wifi_status), wifi_status);
         _last_wifi_status = wifi_status;
+
+        if (wifi_status == WL_CONNECTED) {
+            _wifi_ever_connected    = true;
+            _wifi_error_msg         = nullptr;
+            _wifi_retry_at          = 0;
+            _wifi_connect_start_ms  = 0;
+            _wifi_disconnect_reason = 0;
+        }
+    }
+
+    // Early-timeout: show a generic message while the handshake is still in progress
+    static constexpr uint32_t WIFI_CONNECT_TIMEOUT_MS = 8000;
+    if (!_wifi_ever_connected && !_wifi_error_msg && _wifi_connect_start_ms &&
+        (millis() - _wifi_connect_start_ms) > WIFI_CONNECT_TIMEOUT_MS) {
+        _wifi_error_msg = "Cannot connect";
+        current_scene->reDisplay();
+    }
+
+    // Decode the reason code set by the WiFi disconnect event.
+    if (_wifi_disconnect_reason) {
+        uint8_t reason          = _wifi_disconnect_reason;
+        _wifi_disconnect_reason = 0;
+        dbg_printf("WiFi disconnect reason: %d\n", reason);
+
+        if (!_wifi_ever_connected) {
+            if (reason == WIFI_REASON_NO_AP_FOUND) {
+                _wifi_error_msg = "Network not found";
+                _wifi_retry_at  = millis() + WIFI_RETRY_DELAY_MS;
+                current_scene->reDisplay();
+            } else if (reason == WIFI_REASON_AUTH_FAIL    ||
+                       reason == WIFI_REASON_AUTH_EXPIRE  ||
+                       reason == WIFI_REASON_MIC_FAILURE  ||
+                       reason == WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT) {
+                _wifi_error_msg = "Check password";
+                _wifi_retry_at  = millis() + WIFI_RETRY_DELAY_MS;
+                current_scene->reDisplay();
+            }
+        }
+    }
+
+    // Re-issue WiFi.begin() after a failure so the driver tries again.
+    if (_wifi_retry_at && millis() >= _wifi_retry_at) {
+        _wifi_retry_at         = 0;
+        _wifi_error_msg        = nullptr;   // clear error while retrying
+        _last_wifi_status      = WL_IDLE_STATUS;  // reset so next status change fires
+        _wifi_connect_start_ms = millis();  // reset timeout for the new attempt
+        dbg_printf("WiFi retry: reconnecting to %s\n", _active_cfg.ssid);
+        WiFi.disconnect(false);
+        delay(100);
+        WiFi.begin(_active_cfg.ssid, _active_cfg.password[0] ? _active_cfg.password : nullptr);
     }
 
     // Detect WiFi reconnects so the WebSocket can recover.

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -105,7 +105,12 @@ static void start_dns_resolve() {
     _dns_ok        = false;
     _dns_resolving = true;
     dbg_printf("Resolving hostname (async): %s\n", _active_cfg.fluidnc_ip);
-    xTaskCreate(dnsResolveTask, "dns_resolve", 4096, nullptr, 1, nullptr);
+    BaseType_t task_created = xTaskCreate(dnsResolveTask, "dns_resolve", 4096, nullptr, 1, nullptr);
+    if (task_created != pdPASS) {
+        _dns_resolving = false;
+        _wifi_error_msg = "DNS resolve task start failed";
+        dbg_printf("Failed to start DNS resolve task\n");
+    }
 }
 
 static void ws_begin(const char* host) {

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -117,8 +117,12 @@ extern "C" void fnc_putchar(uint8_t c) {
     // Skip UART XON/XOFF flow-control bytes (irrelevant over WebSocket).
     if (c == 0x11 || c == 0x13) return;
 
-    // Extended single-byte realtime commands: Ctrl-X and 0x80–0x9F.
-    if (c == 0x18 || (c >= 0x80 && c <= 0x9F)) {
+    // Extended single-byte realtime commands: Ctrl-X, 0x80–0x9F, and the
+    // IO-extender commands 0xB0–0xB3 (ACK=0xB2, NAK=0xB3).  FluidNC uses
+    // ACK/NAK flow control when streaming JSON file listings, even over
+    // WebSocket — without it the first chunk arrives and FluidNC stalls
+    // waiting for acknowledgement, leaving the file list empty.
+    if (c == 0x18 || (c >= 0x80 && c <= 0x9F) || (c >= 0xB0 && c <= 0xB3)) {
         if (_ws_connected) ws_send_bin(&c, 1);
         return;
     }
@@ -168,6 +172,7 @@ static void onWsEvent(WStype_t type, uint8_t* payload, size_t length) {
         case WStype_BIN: {
             // Push every received byte into the ring buffer.
             // GrblParserC's fnc_getchar() will drain it character-by-character.
+            dbg_printf("DBG WS RX: type=%d len=%d data='%.80s'\n", (int)type, (int)length, (char*)payload);
             for (size_t i = 0; i < length; i++) {
                 if (payload[i] == '\r') continue;  // Strip CR
                 rx_push(payload[i]);
@@ -477,7 +482,8 @@ void wifi_poll() {
 
     // Explicit status poll every 500 ms.
     // (FluidNC auto-report via $RI is also set when state transitions from
-    // Disconnected in show_state()
+    // Disconnected in show_state(), but we poll here as a belt-and-suspenders
+    // measure until the first status arrives.)
     uint32_t now = millis();
     if (now - _last_status_ms >= STATUS_POLL_MS) {
         _last_status_ms = now;

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -25,9 +25,15 @@
 #define WIFI_AP_PASS       ""          // Open AP — no password needed
 #define PREF_NAMESPACE     "fluidwifi"
 #define WS_SUBPROTOCOL     "arduino"
+#define FLUIDNC_WS_PORT    80
+#define FLUIDNC_WS_PATH    "/"
+#define HARDCODE_TEST_WIFI 1
+#define TEST_WIFI_SSID     "FluidNC"
+#define TEST_WIFI_PASS     "12345678"
+#define TEST_FLUIDNC_IP    "192.168.0.1"
 #define RX_BUF_SIZE        2048
 #define TX_BUF_SIZE        512
-#define PING_INTERVAL_MS   10000       // Application-level PING every 10 s
+#define FLUIDNC_WS_MINIMAL_STARTUP 1
 #define STATUS_POLL_MS     500         // Send '?' every 500 ms while connected
 
 // ─── Globals ─────────────────────────────────────────────────────────────────
@@ -38,7 +44,10 @@ static DNSServer        dnsServer;
 
 static bool _ap_mode       = false;
 static bool _ws_connected  = false;
+static bool _ws_started    = false;
 static bool _wifi_was_connected = false;
+static WiFiConfig _active_cfg = {};
+static wl_status_t _last_wifi_status = WL_IDLE_STATUS;
 
 // Ring buffer for characters received from FluidNC via WebSocket.
 // Written in the WS callback, read by fnc_getchar() (both on the main task).
@@ -51,12 +60,47 @@ static uint8_t _tx_buf[TX_BUF_SIZE];
 static int     _tx_len = 0;
 
 // Timers.
-static uint32_t _last_ping_ms   = 0;
 static uint32_t _last_status_ms = 0;
-static uint16_t _page_id        = 1234;
 
 static void log_wifi_heap(const char* stage) {
     dbg_printf("%s free heap: %u\n", stage, ESP.getFreeHeap());
+}
+
+static const char* wifi_status_name(wl_status_t status) {
+    switch (status) {
+        case WL_NO_SHIELD:
+            return "WL_NO_SHIELD";
+        case WL_IDLE_STATUS:
+            return "WL_IDLE_STATUS";
+        case WL_NO_SSID_AVAIL:
+            return "WL_NO_SSID_AVAIL";
+        case WL_SCAN_COMPLETED:
+            return "WL_SCAN_COMPLETED";
+        case WL_CONNECTED:
+            return "WL_CONNECTED";
+        case WL_CONNECT_FAILED:
+            return "WL_CONNECT_FAILED";
+        case WL_CONNECTION_LOST:
+            return "WL_CONNECTION_LOST";
+        case WL_DISCONNECTED:
+            return "WL_DISCONNECTED";
+        default:
+            return "WL_UNKNOWN";
+    }
+}
+
+static bool ws_send_text(uint8_t* payload, size_t length) {
+    dbg_printf("WS TX text len=%u\n", (unsigned)length);
+    return webSocket.sendTXT(payload, length);
+}
+
+static bool ws_send_bin(const uint8_t* payload, size_t length) {
+    if (length > 0) {
+        dbg_printf("WS TX bin len=%u first=0x%02X\n", (unsigned)length, payload[0]);
+    } else {
+        dbg_printf("WS TX bin len=0\n");
+    }
+    return webSocket.sendBIN(payload, length);
 }
 
 // ─── Ring-buffer helpers ──────────────────────────────────────────────────────
@@ -85,14 +129,14 @@ extern "C" void fnc_putchar(uint8_t c) {
 
     // Extended single-byte realtime commands: Ctrl-X and 0x80–0x9F.
     if (c == 0x18 || (c >= 0x80 && c <= 0x9F)) {
-        if (_ws_connected) webSocket.sendBIN(&c, 1);
+        if (_ws_connected) ws_send_bin(&c, 1);
         return;
     }
 
     // ASCII realtime commands ('?', '!', '~') sent *outside* a text line.
     // GrblParserC calls fnc_putchar() with these as standalone bytes.
     if (_tx_len == 0 && (c == '?' || c == '!' || c == '~')) {
-        if (_ws_connected) webSocket.sendBIN(&c, 1);
+        if (_ws_connected) ws_send_bin(&c, 1);
         return;
     }
 
@@ -100,7 +144,7 @@ extern "C" void fnc_putchar(uint8_t c) {
     _tx_buf[_tx_len++] = c;
     if (c == '\n' || _tx_len >= TX_BUF_SIZE - 1) {
         if (_ws_connected) {
-            webSocket.sendTXT((char*)_tx_buf, _tx_len);
+            ws_send_text(_tx_buf, _tx_len);
         }
         _tx_len = 0;
     }
@@ -117,10 +161,15 @@ static void onWsEvent(WStype_t type, uint8_t* payload, size_t length) {
     switch (type) {
         case WStype_CONNECTED: {
             _ws_connected = true;
-            dbg_println("WS: connected to FluidNC");
+            _last_status_ms = 0;
+            dbg_printf("WS: connected to FluidNC at ws://%s:%d%s\n", _active_cfg.fluidnc_ip, FLUIDNC_WS_PORT, FLUIDNC_WS_PATH);
 
+#if !FLUIDNC_WS_MINIMAL_STARTUP
             // Replay startup log so GrblParserC parses the initial state.
-            webSocket.sendTXT("$SS\n");
+            ws_send_text((uint8_t*)"$SS\n", 4);
+#else
+            dbg_println("WS: minimal startup mode enabled; suppressing automatic startup writes");
+#endif
             break;
         }
 
@@ -132,6 +181,7 @@ static void onWsEvent(WStype_t type, uint8_t* payload, size_t length) {
 
         case WStype_TEXT:
         case WStype_BIN: {
+            dbg_printf("WS RX %s len=%u\n", type == WStype_TEXT ? "text" : "bin", (unsigned)length);
             // Push every received byte into the ring buffer.
             // GrblParserC's fnc_getchar() will drain it character-by-character.
             for (size_t i = 0; i < length; i++) {
@@ -146,9 +196,12 @@ static void onWsEvent(WStype_t type, uint8_t* payload, size_t length) {
             break;
         }
 
+        case WStype_ERROR:
+            dbg_println("WS: error");
+            break;
+
         case WStype_PING:
         case WStype_PONG:
-        case WStype_ERROR:
         case WStype_FRAGMENT_TEXT_START:
         case WStype_FRAGMENT_BIN_START:
         case WStype_FRAGMENT:
@@ -228,6 +281,10 @@ static void handleSave() {
     String pass = httpServer.arg("pass");
     String ip   = httpServer.arg("ip");
 
+    ssid.trim();
+    pass.trim();
+    ip.trim();
+
     if (ssid.length() == 0 || ip.length() == 0) {
         httpServer.send(400, "text/plain", "SSID and IP are required");
         return;
@@ -260,6 +317,15 @@ void wifi_save_config(const char* ssid, const char* password, const char* ip) {
 
 WiFiConfig wifi_load_config() {
     WiFiConfig cfg = {};
+
+#if HARDCODE_TEST_WIFI
+    strncpy(cfg.ssid, TEST_WIFI_SSID, sizeof(cfg.ssid) - 1);
+    strncpy(cfg.password, TEST_WIFI_PASS, sizeof(cfg.password) - 1);
+    strncpy(cfg.fluidnc_ip, TEST_FLUIDNC_IP, sizeof(cfg.fluidnc_ip) - 1);
+    cfg.valid = true;
+    return cfg;
+#endif
+
     Preferences prefs;
     // Open read-write so the namespace is created on first boot, avoiding
     // the NVS_NOT_FOUND error that occurs with read-only on a fresh device.
@@ -281,6 +347,7 @@ WiFiConfig wifi_load_config() {
 void wifi_start_ap_setup() {
     _ap_mode      = true;
     _ws_connected = false;
+    _ws_started   = false;
 
     log_wifi_heap("Starting AP setup");
     WiFi.disconnect(true);
@@ -295,6 +362,10 @@ void wifi_start_ap_setup() {
     dnsServer.start(53, "*", apIP);
 
     httpServer.on("/",      HTTP_GET,  handleRoot);
+    httpServer.on("/generate_204", HTTP_GET, handleRoot);
+    httpServer.on("/hotspot-detect.html", HTTP_GET, handleRoot);
+    httpServer.on("/ncsi.txt", HTTP_GET, handleRoot);
+    httpServer.on("/fwlink", HTTP_GET, handleRoot);
     httpServer.on("/save",  HTTP_POST, handleSave);
     httpServer.onNotFound(handleNotFound);
     httpServer.begin();
@@ -336,8 +407,6 @@ const char* wifi_status_str() {
 }
 
 void wifi_init() {
-    // Random page ID (matches WebUI behaviour).
-    _page_id = (uint16_t)(random(1000, 9999));
     log_wifi_heap("Before WiFi init");
 
     WiFiConfig cfg = wifi_load_config();
@@ -349,14 +418,16 @@ void wifi_init() {
     }
 
     dbg_printf("Connecting to WiFi: %s\n", cfg.ssid);
+    _active_cfg    = cfg;
+    _ws_started    = false;
+    _ws_connected  = false;
+    _wifi_was_connected = false;
+    _last_wifi_status = WL_IDLE_STATUS;
+    WiFi.persistent(false);
     WiFi.mode(WIFI_STA);
+    WiFi.setSleep(false);
     WiFi.setAutoReconnect(true);
     WiFi.begin(cfg.ssid, cfg.password[0] ? cfg.password : nullptr);
-
-    // Configure WebSocket client — it will connect once WiFi is up.
-    webSocket.begin(cfg.fluidnc_ip, 80, "/", WS_SUBPROTOCOL);
-    webSocket.onEvent(onWsEvent);
-    webSocket.setReconnectInterval(3000);  // retry every 3 s on disconnect
 }
 
 void wifi_poll() {
@@ -366,43 +437,56 @@ void wifi_poll() {
         return;
     }
 
-    // Drive the WebSocket state machine.
-    webSocket.loop();
+    wl_status_t wifi_status = WiFi.status();
+    if (wifi_status != _last_wifi_status) {
+        dbg_printf("WiFi status: %s (%d)\n", wifi_status_name(wifi_status), wifi_status);
+        _last_wifi_status = wifi_status;
+    }
 
     // Detect WiFi reconnects so the WebSocket can recover.
-    bool now_connected = wifi_is_connected();
+    bool now_connected = wifi_status == WL_CONNECTED;
     if (now_connected && !_wifi_was_connected) {
         dbg_printf("WiFi connected — IP: %s\n",
                    WiFi.localIP().toString().c_str());
+        dbg_printf("Starting WebSocket: ws://%s:%d%s\n", _active_cfg.fluidnc_ip, FLUIDNC_WS_PORT, FLUIDNC_WS_PATH);
+        webSocket.begin(_active_cfg.fluidnc_ip, FLUIDNC_WS_PORT, FLUIDNC_WS_PATH, WS_SUBPROTOCOL);
+        webSocket.onEvent(onWsEvent);
+        webSocket.setReconnectInterval(3000);  // retry every 3 s on disconnect
+        webSocket.enableHeartbeat(15000, 3000, 2);
+        _ws_started = true;
     }
     if (!now_connected && _wifi_was_connected) {
+        if (_ws_started) {
+            webSocket.disconnect();
+            _ws_started = false;
+        }
         _ws_connected = false;
         set_disconnected_state();
         dbg_println("WiFi lost");
     }
     _wifi_was_connected = now_connected;
 
+    if (_ws_started) {
+        // Drive the WebSocket state machine only after WiFi is up.
+        webSocket.loop();
+    }
+
     if (!_ws_connected) return;
 
     uint32_t now = millis();
 
-    // Application-level PING every 10 s (keeps FluidNC page-tracking happy).
-    if (now - _last_ping_ms >= PING_INTERVAL_MS) {
-        _last_ping_ms = now;
-        char ping[32];
-        snprintf(ping, sizeof(ping), "PING:%d\n", _page_id);
-        webSocket.sendTXT(ping);
-    }
-
+#if !FLUIDNC_WS_MINIMAL_STARTUP
     // Explicit status poll every 500 ms.
     // (FluidNC auto-report via $RI is also set when state transitions from
-    // Disconnected in show_state(), but we poll here as a belt-and-suspenders
-    // measure until the first status arrives.)
+    // Disconnected in show_state()
     if (now - _last_status_ms >= STATUS_POLL_MS) {
         _last_status_ms = now;
         uint8_t qmark = '?';
-        webSocket.sendBIN(&qmark, 1);
+        ws_send_bin(&qmark, 1);
     }
+#else
+    (void)now;
+#endif
 }
 
 // Stub: flow control is a no-op over WebSocket.

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -11,6 +11,7 @@
 #include "WiFiConnection.h"
 #include "FluidNCModel.h"
 #include "System.h"
+#include "Scene.h"   // current_scene->reDisplay()
 
 #include <Esp.h>
 #include <WiFi.h>
@@ -152,6 +153,8 @@ static void onWsEvent(WStype_t type, uint8_t* payload, size_t length) {
             _ws_connected = true;
             _last_status_ms = 0;
             dbg_printf("WS: connected to FluidNC at ws://%s:%d%s\n", _active_cfg.fluidnc_ip, FLUIDNC_WS_PORT, FLUIDNC_WS_PATH);
+            // Update the badge immediately; state report from FluidNC will follow shortly.
+            current_scene->reDisplay();
             break;
         }
 
@@ -432,6 +435,8 @@ void wifi_poll() {
         webSocket.setReconnectInterval(3000);  // retry every 3 s on disconnect
         webSocket.enableHeartbeat(15000, 3000, 2);
         _ws_started = true;
+        // WiFi just came up — update badge from "WiFi..." to "WiFi OK".
+        current_scene->reDisplay();
     }
     if (!now_connected && _wifi_was_connected) {
         if (_ws_started) {

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -56,6 +56,7 @@ static uint32_t         _wifi_retry_at            = 0;        // millis() target
 static volatile uint8_t _wifi_disconnect_reason   = 0;        // set by WiFi event, read in wifi_poll()
 static bool             _wifi_ever_connected      = false;    // true once WL_CONNECTED seen; blocks false-positive on drops
 static uint32_t         _wifi_connect_start_ms    = 0;        // millis() when WiFi.begin() was last issued
+static uint8_t          _handshake_timeout_count  = 0;        // consecutive 4-way handshake timeouts; real auth fail after threshold
 
 // Ring buffer for characters received from FluidNC via WebSocket.
 // Written in the WS callback, read by fnc_getchar() (both on the main task).
@@ -643,6 +644,7 @@ void wifi_init() {
     _wifi_disconnect_reason  = 0;
     _wifi_ever_connected     = false;
     _wifi_connect_start_ms   = 0;  // set after WiFi.begin() below
+    _handshake_timeout_count = 0;
 
     static bool _event_registered = false;
     if (!_event_registered) {
@@ -677,10 +679,11 @@ void wifi_poll() {
         _last_wifi_status = wifi_status;
 
         if (wifi_status == WL_CONNECTED) {
-            _wifi_ever_connected    = true;
-            _wifi_error_msg         = nullptr;
-            _wifi_retry_at          = 0;
-            _wifi_connect_start_ms  = 0;
+            _wifi_ever_connected       = true;
+            _wifi_error_msg            = nullptr;
+            _wifi_retry_at             = 0;
+            _wifi_connect_start_ms     = 0;
+            _handshake_timeout_count   = 0;
             _wifi_disconnect_reason = 0;
             // Re-arm auto-reconnect now that we're up; it was disabled on any
             // prior failure so drops after a successful session still recover.
@@ -710,15 +713,27 @@ void wifi_poll() {
             bool        stop_driver = false;
             bool        allow_retry = false;
 
-            if (reason == WIFI_REASON_AUTH_FAIL          ||
-                reason == WIFI_REASON_AUTH_EXPIRE        ||
-                reason == WIFI_REASON_MIC_FAILURE        ||
-                reason == WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT) {
-                // Auth errors: wrong password can only be fixed by the user —
-                // stop the driver completely and do not schedule any retry.
-                new_msg     = MSG_CHECK_PASS;
+            if (reason == WIFI_REASON_AUTH_FAIL   ||
+                reason == WIFI_REASON_AUTH_EXPIRE  ||
+                reason == WIFI_REASON_MIC_FAILURE) {                new_msg     = MSG_CHECK_PASS;
                 stop_driver = true;
                 allow_retry = false;
+            } else if (reason == WIFI_REASON_4WAY_HANDSHAKE_TIMEOUT) {
+                // Handle cold-boot handshake timeout.
+                // Retry up to 3 times before concluding it is an actual auth failure.
+                _handshake_timeout_count++;
+                if (_handshake_timeout_count >= 3) {
+                    new_msg     = MSG_CHECK_PASS;
+                    stop_driver = true;
+                    allow_retry = false;
+                } else {
+                    // Silent retry after a short delay — do not show an error yet.
+                    stop_driver = false;
+                    allow_retry = true;
+                    if (!_wifi_retry_at) {
+                        _wifi_retry_at = millis() + 2000;
+                    }
+                }
             } else if (reason == WIFI_REASON_NO_AP_FOUND) {
                 // NO_AP_FOUND fires spuriously during retry rescans even when
                 // the AP is present but rejecting credentials — only show

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -389,6 +389,16 @@ const char* wifi_status_str() {
     return "Connected";
 }
 
+int wifi_signal_bars() {
+    if (!wifi_is_connected()) return 0;
+    int rssi = WiFi.RSSI();
+    if (rssi >= -55) return 4;   // Excellent
+    if (rssi >= -65) return 3;   // Good
+    if (rssi >= -75) return 2;   // Fair
+    if (rssi >= -85) return 1;   // Weak
+    return 0;                    // Very weak
+}
+
 void wifi_init() {
     WiFiConfig cfg = wifi_load_config();
 

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -273,6 +273,13 @@ static void handleSave() {
     pass.trim();
     ip.trim();
 
+    String cleanIp;
+    for (int i = 0; i < (int)ip.length(); i++) {
+        char c = ip[i];
+        if ((c >= '0' && c <= '9') || c == '.') cleanIp += c;
+    }
+    ip = cleanIp;
+
     if (ssid.length() == 0 || ip.length() == 0) {
         httpServer.send(400, "text/plain", "SSID and IP are required");
         return;
@@ -324,6 +331,8 @@ WiFiConfig wifi_load_config() {
     prefs.end();
 
     if (ssid.length() > 0 && ip.length() > 0) {
+        dbg_printf("NVS loaded: ssid='%s' (len=%d) ip='%s' (len=%d)\n",
+                   ssid.c_str(), ssid.length(), ip.c_str(), ip.length());
         strncpy(cfg.ssid,      ssid.c_str(), sizeof(cfg.ssid)      - 1);
         strncpy(cfg.password,  pass.c_str(), sizeof(cfg.password)  - 1);
         strncpy(cfg.fluidnc_ip, ip.c_str(), sizeof(cfg.fluidnc_ip) - 1);
@@ -412,13 +421,15 @@ void wifi_init() {
         return;
     }
 
-    dbg_printf("Connecting to WiFi: %s\n", cfg.ssid);
+    dbg_printf("Connecting to WiFi: %s  FluidNC: %s\n", cfg.ssid, cfg.fluidnc_ip);
     _active_cfg    = cfg;
     _ws_started    = false;
     _ws_connected  = false;
     _wifi_was_connected = false;
     _last_wifi_status = WL_IDLE_STATUS;
     WiFi.persistent(false);
+    WiFi.disconnect(true);  // Ensure clean driver state (especially after AP mode).
+    delay(100);
     WiFi.mode(WIFI_STA);
     WiFi.setSleep(false);
     WiFi.setAutoReconnect(true);

--- a/src/WiFiConnection.h
+++ b/src/WiFiConnection.h
@@ -38,4 +38,7 @@ WiFiConfig wifi_load_config();
 const char* wifi_ap_ssid();
 const char* wifi_status_str();
 
+// Returns signal strength as 0–4 bars (0 = no WiFi / disconnected).
+int wifi_signal_bars();
+
 #endif  // ARDUINO

--- a/src/WiFiConnection.h
+++ b/src/WiFiConnection.h
@@ -5,6 +5,8 @@
 
 #ifdef ARDUINO
 
+#include <stdint.h>
+
 struct WiFiConfig {
     char ssid[64];
     char password[64];
@@ -40,5 +42,20 @@ const char* wifi_status_str();
 
 // Returns signal strength as 0–4 bars (0 = no WiFi / disconnected).
 int wifi_signal_bars();
+
+// ── WebSocket transport primitives (used by fnc_putchar/fnc_getchar routing) ──
+// Send one byte to FluidNC via WebSocket.
+void ws_putchar(uint8_t c);
+// Receive one byte from the WebSocket ring buffer (-1 if empty).
+int  ws_getchar();
+
+// ── Runtime transport mode ────────────────────────────────────────────────────
+// When uart_mode is true the WiFi stack is not started and
+// fnc_putchar/fnc_getchar route to the ESP-IDF UART driver instead.
+// The mode is persisted in NVS (namespace "fluidwifi", key "uart_mode").
+bool wifi_use_uart_mode();          // cached after first read
+void wifi_set_uart_mode(bool uart); // write to NVS and update cache
+
+bool wifi_is_first_boot();
 
 #endif  // ARDUINO

--- a/src/WiFiConnection.h
+++ b/src/WiFiConnection.h
@@ -1,0 +1,41 @@
+#pragma once
+
+// WiFi/WebSocket connection layer for FluidDial
+// Replaces UART (fnc_putchar/fnc_getchar) with WebSocket transport
+
+#ifdef ARDUINO
+
+struct WiFiConfig {
+    char ssid[64];
+    char password[64];
+    char fluidnc_ip[40];
+    bool valid;
+};
+
+// Initialise WiFi. If no credentials saved, starts AP setup mode.
+void wifi_init();
+
+// Must be called from main loop() — processes WebSocket events,
+// DNS and HTTP requests in AP mode, ping timers, etc.
+void wifi_poll();
+
+bool wifi_is_connected();       // ESP32 STA joined the network
+bool websocket_is_connected();  // WebSocket connection to FluidNC is up
+bool wifi_in_ap_mode();         // Running as access point for initial setup
+
+// Start a captive-portal AP named "FluidDial".
+// User connects to it, browses to 192.168.4.1 and fills in the form.
+void wifi_start_ap_setup();
+
+// Stop the AP / HTTP server and restart (called after saving config).
+void wifi_stop_ap_and_restart();
+
+// Persistent credential storage (NVS via Preferences).
+void       wifi_save_config(const char* ssid, const char* password, const char* ip);
+WiFiConfig wifi_load_config();
+
+// Convenience accessors for display.
+const char* wifi_ap_ssid();
+const char* wifi_status_str();
+
+#endif  // ARDUINO

--- a/src/WiFiConnection.h
+++ b/src/WiFiConnection.h
@@ -43,7 +43,7 @@ WiFiConfig wifi_load_config();
 // Convenience accessors for display.
 const char* wifi_ap_ssid();
 const char* wifi_status_str();
-
+const bool wifi_not_ready();
 // Returns signal strength as 0–4 bars (0 = no WiFi / disconnected).
 int wifi_signal_bars();
 

--- a/src/WiFiConnection.h
+++ b/src/WiFiConnection.h
@@ -47,6 +47,10 @@ const bool wifi_not_ready();
 // Returns signal strength as 0–4 bars (0 = no WiFi / disconnected).
 int wifi_signal_bars();
 
+const char* wifi_last_error();
+
+WiFiConfig wifi_active_config();
+
 // ── WebSocket transport primitives (used by fnc_putchar/fnc_getchar routing) ──
 // Send one byte to FluidNC via WebSocket.
 void ws_putchar(uint8_t c);

--- a/src/WiFiConnection.h
+++ b/src/WiFiConnection.h
@@ -32,6 +32,10 @@ void wifi_start_ap_setup();
 // Stop the AP / HTTP server and restart (called after saving config).
 void wifi_stop_ap_and_restart();
 
+// Stop the AP / HTTP server without restarting (used when the user wants
+// to navigate back to the settings view to switch transport mode).
+void wifi_stop_ap();
+
 // Persistent credential storage (NVS via Preferences).
 void       wifi_save_config(const char* ssid, const char* password, const char* ip);
 WiFiConfig wifi_load_config();

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -91,7 +91,11 @@ void WiFiSetupScene::onGreenButtonPress() {
 }
 
 void WiFiSetupScene::onDialButtonPress() {
-    activate_scene(&displaySettingsScene);
+    if (wifi_in_ap_mode()) {
+        activate_scene(&menuScene);
+    } else {
+        activate_scene(&displaySettingsScene);
+    }
 }
 
 void WiFiSetupScene::onTouchClick() {

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -16,12 +16,12 @@ extern const char* git_info;
 
 // ─── Geometry ─────────────────────────────────────────────────────────────────
 
-static constexpr int BX = 50,  BY  = 28,  BW  = 140, BH  = 34;  // badge
-static constexpr int CX = 15,  CW  = 210, CH  = 22,  CI  = 7;   // info cards
-static constexpr int SBX = 20, SBY = 152, SBW = 200, SBH = 34;  // switch button
+static constexpr int BX = 50,  BY  = 28,  BW  = 140, BH  = 34;  // status badge
+static constexpr int CX = 15,  CW  = 210, CH  = 28,  CI  = 8;   // info cards
+static constexpr int SBX = 20, SBY = 166, SBW = 200, SBH = 36;  // switch button
 
-static constexpr int CARD_Y0    = 70;
-static constexpr int CARD_PITCH = CH + 3;  // card height + gap
+static constexpr int CARD_Y0    = 68;
+static constexpr int CARD_PITCH = CH + 4;  // 32 px per card row
 
 // ─── Card drawing helpers ──────────────────────────────────────────────────────
 
@@ -99,20 +99,18 @@ void WiFiSetupScene::drawApView() {
     centered_text("AP Setup Mode", BY + BH / 2 + 3, WHITE, SMALL);
 
     int y = CARD_Y0;
-    drawCard(y,          "Connect to", wifi_ap_ssid(), CYAN);
-    y += CARD_PITCH;
-    drawCard(y,          "Browse to",  "192.168.4.1",  GREEN);
-    y += CH + 14;
+    drawCard(y,     "Connect to", wifi_ap_ssid(), CYAN);  y += CARD_PITCH;
+    drawCard(y,     "Browse to",  "192.168.4.1",  GREEN); y += CH + 14;
 
-    centered_text("Fill in WiFi + FluidNC IP,", y, LIGHTGREY, TINY);
+    centered_text("Fill in WiFi + FluidNC IP,", y,      LIGHTGREY, TINY);
     centered_text("then tap Save.",              y + 16, LIGHTGREY, TINY);
 
     drawButtonLegends("Stop AP", "Restart", "Menu");
 }
 
 void WiFiSetupScene::drawSettingsView() {
-    bool        uart_mode = wifi_use_uart_mode();
-    WiFiConfig  cfg       = wifi_load_config();
+    bool       uart_mode = wifi_use_uart_mode();
+    WiFiConfig cfg       = wifi_load_config();
 
     // ── Status badge ──────────────────────────────────────────────────────────
     int        badge_fill;
@@ -140,9 +138,8 @@ void WiFiSetupScene::drawSettingsView() {
     int y = CARD_Y0;
 
     if (uart_mode) {
-        drawCard(y, "Baud Rate", "1 Mbaud");
-        // No machine-state badge: state arrives over UART, not WebSocket,
-        // and drawStatusTiny needs the WS state machine.
+        drawCard(y, "Baud Rate",  "1 Mbaud", CYAN);  y += CARD_PITCH;
+        drawCard(y, "Transport",  "Wired UART");
     } else if (cfg.valid) {
         drawCardAuto(y, "Network",  cfg.ssid);           y += CARD_PITCH;
         drawCard(y,     "FluidNC",  cfg.fluidnc_ip);     y += CARD_PITCH;
@@ -150,17 +147,12 @@ void WiFiSetupScene::drawSettingsView() {
         char sigbuf[24];
         int  bars = wifi_signal_bars();
         snprintf(sigbuf, sizeof(sigbuf), "%s (%d/4)", signal_str(bars), bars);
-        drawCard(y,     "Signal",   sigbuf);             y += CARD_PITCH;
-
-        if (websocket_is_connected()) {
-            drawStatusTiny(y + 2);
-        }
+        drawCard(y, "Signal", sigbuf);
     } else {
         // WiFi mode but no credentials stored yet
-        centered_text("No credentials saved.", y + 8, LIGHTGREY, SMALL);
-        y += 36;
-        centered_text("Press Green (AP Setup)",   y, LIGHTGREY, TINY);
-        centered_text("to configure WiFi.",        y + 16, LIGHTGREY, TINY);
+        centered_text("No WiFi credentials saved.", CARD_Y0 + 12, LIGHTGREY, SMALL);
+        centered_text("Press Green to run AP Setup", CARD_Y0 + 38, LIGHTGREY, TINY);
+        centered_text("and configure your network.", CARD_Y0 + 54, LIGHTGREY, TINY);
     }
 
     // ── Mode-switch button ────────────────────────────────────────────────────
@@ -171,13 +163,7 @@ void WiFiSetupScene::drawSettingsView() {
         centered_text(sw_label, SBY + SBH / 2 + 3, sw_color, SMALL);
     }
 
-    // ── Version footer ────────────────────────────────────────────────────────
-    std::string ver = "Ver ";
-    ver += git_info;
-    centered_text(ver.c_str(), 196, DARKGREY, TINY);
-
     // ── Button legends ────────────────────────────────────────────────────────
-    // Red  = switch mode (always).  Green = AP Setup (WiFi) / Restart (UART).
     const char* red_label   = uart_mode ? "Use WiFi"  : "Use UART";
     const char* green_label = uart_mode ? "Restart"   : "AP Setup";
     drawButtonLegends(red_label, green_label, "Menu");

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -186,7 +186,7 @@ void WiFiSetupScene::drawSettingsView() {
     int y = CARD_Y0;
 
     if (uart_mode) {
-        y += 14;
+        y += 28;
         centered_text("1 Mbaud", y, 0xe02b2b, SMALL);
         y += 20;
         centered_text("Wired UART", y, WHITE, TINY);

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -156,7 +156,7 @@ void WiFiSetupScene::drawSettingsView() {
         badge_fill    = 0x003300;
         badge_outline = 0x66ff66;
         badge_label   = "Connected";
-        badge_text    = BLACK;
+        badge_text    = 0x66ff66;
     } else if (wf_ok) {
         // WiFi up — waiting for FluidNC WebSocket
         static const char* nc_frames[] = { "FluidNC", "FluidNC.", "FluidNC..", "FluidNC..." };
@@ -221,18 +221,6 @@ void WiFiSetupScene::drawSettingsView() {
             centered_text(cfg.fluidnc_ip, y, ip_color, SMALL);
             y += 22;
         }
-
-        if (ws_ok) {
-            // Signal strength — only meaningful once fully connected
-            int         bars     = wifi_signal_bars();
-            const char* bars_str = "○○○○○";
-            int         bar_color = RED;
-            if (bars >= 4)      { bars_str = "●●●●●"; bar_color = GREEN; }
-            else if (bars == 3) { bars_str = "●●●○○"; bar_color = YELLOW; }
-            else if (bars == 2) { bars_str = "●●○○○"; bar_color = YELLOW; }
-            else if (bars == 1) { bars_str = "●○○○○"; bar_color = RED; }
-            centered_text(bars_str, y, bar_color, SMALL);
-        }
     }
 
     // ── Mode-switch button ────────────────────────────────────────────────────
@@ -257,7 +245,7 @@ void WiFiSetupScene::reDisplay() {
     if (wifi_in_ap_mode() || wifi_use_uart_mode() || !wifi_active_config().valid) {
         title = "Connection Settings";
     } else if (websocket_is_connected()) {
-        title = "Connection Established";
+        title = " Connected to FluidNC";
     } else if (wifi_is_connected()) {
         title = " Connecting to FluidNC";
     } else {

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -14,60 +14,70 @@
 extern Scene     menuScene;
 extern const char* git_info;
 
-// Card geometry shared by connected- and AP-views.
-static constexpr int CX = 15;   // card left edge
-static constexpr int CW = 210;  // card widt
-static constexpr int CH = 26;   // card height
-static constexpr int CI = 7;    // card text inset from each side
+// ─── Geometry ─────────────────────────────────────────────────────────────────
 
-// Badge geometry (status pill at top of content area).
-static constexpr int BX = 50;   // badge left edge
-static constexpr int BW = 140;  // badge width
-static constexpr int BH = 34;   // badge height
-static constexpr int BY = 28;   // badge top
+static constexpr int BX = 50,  BY  = 28,  BW  = 140, BH  = 34;  // badge
+static constexpr int CX = 15,  CW  = 210, CH  = 22,  CI  = 7;   // info cards
+static constexpr int SBX = 20, SBY = 152, SBW = 200, SBH = 34;  // switch button
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
+static constexpr int CARD_Y0    = 70;
+static constexpr int CARD_PITCH = CH + 3;  // card height + gap
 
-static void drawCard(int y, const char* label, const char* value,
-                     int value_color = WHITE) {
+// ─── Card drawing helpers ──────────────────────────────────────────────────────
+
+static void drawCard(int y, const char* label, const char* value, int val_color = WHITE) {
     drawOutlinedRect(CX, y, CW, CH, NAVY, WHITE);
     int mid = y + CH / 2 + 2;
-    text(label, CX + CI,      mid, DARKGREY, TINY,  middle_left);
-    text(value, CX + CW - CI, mid, value_color, SMALL, middle_right);
+    text(label, CX + CI,      mid, DARKGREY,  TINY,  middle_left);
+    text(value, CX + CW - CI, mid, val_color, SMALL, middle_right);
 }
 
-static void drawCardAuto(int y, const char* label, const char* value,
-                         int value_color = WHITE) {
+static void drawCardAuto(int y, const char* label, const char* value, int val_color = WHITE) {
     drawOutlinedRect(CX, y, CW, CH, NAVY, WHITE);
     int mid = y + CH / 2 + 2;
     text(label, CX + CI, mid, DARKGREY, TINY, middle_left);
-    // Auto-fit so long SSIDs shrink instead of overflowing.
     static constexpr int VALUE_W = 130;
-    auto_text(std::string(value), CX + CW - CI, mid, VALUE_W,
-              value_color, SMALL, middle_right);
+    auto_text(std::string(value), CX + CW - CI, mid, VALUE_W, val_color, SMALL, middle_right);
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+static const char* signal_str(int bars) {
+    switch (bars) {
+        case 4:  return "Excellent";
+        case 3:  return "Good";
+        case 2:  return "Fair";
+        case 1:  return "Weak";
+        default: return "None";
+    }
 }
 
 // ─── Event handlers ───────────────────────────────────────────────────────────
 
-void WiFiSetupScene::onEntry(void* arg) {
-    reDisplay();
-}
+void WiFiSetupScene::onEntry(void* arg)    { reDisplay(); }
+void WiFiSetupScene::onStateChange(state_t){ reDisplay(); }
 
-void WiFiSetupScene::onStateChange(state_t) {
-    reDisplay();
+void WiFiSetupScene::switchModeAndRestart() {
+    wifi_set_uart_mode(!wifi_use_uart_mode());
+    ESP.restart();
 }
 
 void WiFiSetupScene::onRedButtonPress() {
     if (wifi_in_ap_mode()) {
         wifi_stop_ap_and_restart();
     } else {
-        wifi_start_ap_setup();
-        reDisplay();
+        switchModeAndRestart();
     }
 }
 
 void WiFiSetupScene::onGreenButtonPress() {
-    ESP.restart();
+    if (!wifi_in_ap_mode() && !wifi_use_uart_mode()) {
+        // WiFi mode: launch AP for credential entry
+        wifi_start_ap_setup();
+        reDisplay();
+    } else {
+        ESP.restart();
+    }
 }
 
 void WiFiSetupScene::onDialButtonPress() {
@@ -75,88 +85,113 @@ void WiFiSetupScene::onDialButtonPress() {
 }
 
 void WiFiSetupScene::onTouchClick() {
-    onRedButtonPress();
+    if (wifi_in_ap_mode()) {
+        wifi_stop_ap_and_restart();
+    } else {
+        switchModeAndRestart();
+    }
 }
 
 // ─── Drawing ──────────────────────────────────────────────────────────────────
 
 void WiFiSetupScene::drawApView() {
-    // ── AP status badge ────────────────────────────────────────────────────────
     drawOutlinedRect(BX, BY, BW, BH, 0x8400 /* dark orange */, WHITE);
-    centered_text("AP Mode Active", BY + BH / 2 + 3, WHITE, SMALL);
+    centered_text("AP Setup Mode", BY + BH / 2 + 3, WHITE, SMALL);
 
-    // ── Info cards ────────────────────────────────────────────────────────────
-    int y = 70;
-    drawCard(y, "Connect to", wifi_ap_ssid(), CYAN);
-    y += CH + 4;
-    drawCard(y, "Then open", "192.168.4.1", GREEN);
+    int y = CARD_Y0;
+    drawCard(y,          "Connect to", wifi_ap_ssid(), CYAN);
+    y += CARD_PITCH;
+    drawCard(y,          "Browse to",  "192.168.4.1",  GREEN);
     y += CH + 14;
 
-    // ── Instructions ─────────────────────────────────────────────────────────
-    centered_text("Browse to the IP above,", y, LIGHTGREY, TINY);
-    y += 16;
-    centered_text("fill in WiFi + FluidNC IP,", y, LIGHTGREY, TINY);
-    y += 16;
-    centered_text("then press Save.", y, LIGHTGREY, TINY);
+    centered_text("Fill in WiFi + FluidNC IP,", y, LIGHTGREY, TINY);
+    centered_text("then tap Save.",              y + 16, LIGHTGREY, TINY);
 
     drawButtonLegends("Stop AP", "Restart", "Menu");
 }
 
-void WiFiSetupScene::drawConnectedView() {
-    WiFiConfig cfg = wifi_load_config();
-
-    if (!cfg.valid) {
-        // ── Not configured ─────────────────────────────────────────────────────
-        drawOutlinedRect(BX, BY, BW, BH, RED, WHITE);
-        centered_text("Not Configured", BY + BH / 2 + 3, WHITE, SMALL);
-
-        centered_text("Press Red or touch to", 112, LIGHTGREY, TINY);
-        centered_text("start WiFi setup.", 130, LIGHTGREY, TINY);
-
-        drawButtonLegends("AP Setup", "Restart", "Menu");
-        return;
-    }
+void WiFiSetupScene::drawSettingsView() {
+    bool        uart_mode = wifi_use_uart_mode();
+    WiFiConfig  cfg       = wifi_load_config();
 
     // ── Status badge ──────────────────────────────────────────────────────────
-    bool ws_ok       = websocket_is_connected();
-    bool wf_ok       = wifi_is_connected();
-    int  badge_fill  = ws_ok ? GREEN : wf_ok ? YELLOW : RED;
-    int  badge_text  = BLACK;
+    int        badge_fill;
+    int        badge_text = BLACK;
+    const char* badge_label;
 
+    if (uart_mode) {
+        badge_fill  = BLUE;
+        badge_label = "UART Mode";
+        badge_text  = WHITE;
+    } else if (!cfg.valid) {
+        badge_fill  = RED;
+        badge_label = "Not Configured";
+        badge_text  = WHITE;
+    } else {
+        bool ws_ok  = websocket_is_connected();
+        bool wf_ok  = wifi_is_connected();
+        badge_fill  = ws_ok ? GREEN : wf_ok ? YELLOW : RED;
+        badge_label = wifi_status_str();
+    }
     drawOutlinedRect(BX, BY, BW, BH, badge_fill, WHITE);
-    centered_text(wifi_status_str(), BY + BH / 2 + 3, badge_text, SMALL);
+    centered_text(badge_label, BY + BH / 2 + 3, badge_text, SMALL);
 
     // ── Info cards ────────────────────────────────────────────────────────────
-    int y = 70;
-    drawCardAuto(y, "Network", cfg.ssid);
-    y += CH + 4;
-    drawCard(y, "FluidNC IP", cfg.fluidnc_ip);
-    y += CH + 6;
+    int y = CARD_Y0;
 
-    // ── Machine state badge (only when WebSocket is live) ─────────────────────
-    if (ws_ok) {
-        drawStatusTiny(y);
+    if (uart_mode) {
+        drawCard(y, "Baud Rate", "1 Mbaud");
+        // No machine-state badge: state arrives over UART, not WebSocket,
+        // and drawStatusTiny needs the WS state machine.
+    } else if (cfg.valid) {
+        drawCardAuto(y, "Network",  cfg.ssid);           y += CARD_PITCH;
+        drawCard(y,     "FluidNC",  cfg.fluidnc_ip);     y += CARD_PITCH;
+
+        char sigbuf[24];
+        int  bars = wifi_signal_bars();
+        snprintf(sigbuf, sizeof(sigbuf), "%s (%d/4)", signal_str(bars), bars);
+        drawCard(y,     "Signal",   sigbuf);             y += CARD_PITCH;
+
+        if (websocket_is_connected()) {
+            drawStatusTiny(y + 2);
+        }
+    } else {
+        // WiFi mode but no credentials stored yet
+        centered_text("No credentials saved.", y + 8, LIGHTGREY, SMALL);
+        y += 36;
+        centered_text("Press Green (AP Setup)",   y, LIGHTGREY, TINY);
+        centered_text("to configure WiFi.",        y + 16, LIGHTGREY, TINY);
     }
 
-    // ── Footer ────────────────────────────────────────────────────────────────
+    // ── Mode-switch button ────────────────────────────────────────────────────
+    {
+        const char* sw_label = uart_mode ? "Switch to WiFi" : "Switch to UART";
+        int         sw_color = uart_mode ? GREEN : BLUE;
+        drawOutlinedRect(SBX, SBY, SBW, SBH, NAVY, sw_color);
+        centered_text(sw_label, SBY + SBH / 2 + 3, sw_color, SMALL);
+    }
+
+    // ── Version footer ────────────────────────────────────────────────────────
     std::string ver = "Ver ";
     ver += git_info;
-    centered_text(ver.c_str(), 182, DARKGREY, TINY);
+    centered_text(ver.c_str(), 196, DARKGREY, TINY);
 
-    drawButtonLegends("AP Setup", "Restart", "Menu");
+    // ── Button legends ────────────────────────────────────────────────────────
+    // Red  = switch mode (always).  Green = AP Setup (WiFi) / Restart (UART).
+    const char* red_label   = uart_mode ? "Use WiFi"  : "Use UART";
+    const char* green_label = uart_mode ? "Restart"   : "AP Setup";
+    drawButtonLegends(red_label, green_label, "Menu");
 }
 
 void WiFiSetupScene::reDisplay() {
     background();
     drawMenuTitle(name());
-
-    // divider
     drawRect(55, 22, 130, 1, 0, DARKGREY);
 
     if (wifi_in_ap_mode()) {
         drawApView();
     } else {
-        drawConnectedView();
+        drawSettingsView();
     }
 
     drawError();

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -11,6 +11,7 @@
 #include "Menu.h"
 #include "System.h"
 #include "Button.h"
+#include "DisplaySettingsScene.h"
 
 extern Scene     menuScene;
 extern const char* git_info;
@@ -90,7 +91,7 @@ void WiFiSetupScene::onGreenButtonPress() {
 }
 
 void WiFiSetupScene::onDialButtonPress() {
-    activate_scene(&menuScene);
+    activate_scene(&displaySettingsScene);
 }
 
 void WiFiSetupScene::onTouchClick() {
@@ -207,7 +208,7 @@ void WiFiSetupScene::drawSettingsView() {
     // ── Button legends ────────────────────────────────────────────────────────
     const char* red_label   = "Back";
     const char* green_label = uart_mode ? "Restart" : "Setup";
-    drawButtonLegends(red_label, green_label, "Info");
+    drawButtonLegends(red_label, green_label, "Display");
 }
 
 void WiFiSetupScene::reDisplay() {

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -1,0 +1,132 @@
+// 2026 - Figamore
+// Use of this source code is governed by a GPLv3 license.
+//
+// Shows connection status and offers AP-mode setup.
+
+#ifdef ARDUINO
+
+#include "WiFiSetupScene.h"
+#include "WiFiConnection.h"
+#include "Drawing.h"
+#include "Menu.h"
+#include "System.h"
+
+extern Scene menuScene;
+extern const char* git_info;
+
+// ─── Event handlers ───────────────────────────────────────────────────────────
+
+void WiFiSetupScene::onEntry(void* arg) {
+    reDisplay();
+}
+
+void WiFiSetupScene::onStateChange(state_t) {
+    reDisplay();
+}
+
+void WiFiSetupScene::onRedButtonPress() {
+    if (wifi_in_ap_mode()) {
+        wifi_stop_ap_and_restart();
+    } else {
+        wifi_start_ap_setup();
+        reDisplay();
+    }
+}
+
+void WiFiSetupScene::onGreenButtonPress() {
+    ESP.restart();
+}
+
+void WiFiSetupScene::onDialButtonPress() {
+    activate_scene(&menuScene);
+}
+
+void WiFiSetupScene::onTouchClick() {
+    // Same toggle as red button — convenient for single-button displays.
+    onRedButtonPress();
+}
+
+// ─── Drawing ──────────────────────────────────────────────────────────────────
+
+void WiFiSetupScene::drawApView() {
+    const int cx = 120;   // horizontal centre for centred text
+    int y = 60;
+
+    centered_text("AP Mode Active", y, YELLOW, SMALL);
+    y += 26;
+
+    centered_text("Connect your device to:", y, LIGHTGREY, TINY);
+    y += 20;
+    centered_text(wifi_ap_ssid(), y, WHITE, SMALL);
+    y += 26;
+
+    centered_text("Then open a browser at:", y, LIGHTGREY, TINY);
+    y += 20;
+    centered_text("192.168.4.1", y, GREEN, SMALL);
+    y += 26;
+
+    centered_text("Fill in the form to", y, LIGHTGREY, TINY);
+    y += 18;
+    centered_text("configure WiFi + FluidNC", y, LIGHTGREY, TINY);
+
+    drawButtonLegends("Stop AP", "Restart", "Menu");
+}
+
+void WiFiSetupScene::drawConnectedView() {
+    WiFiConfig cfg  = wifi_load_config();
+    int        y    = 58;
+
+    if (!cfg.valid) {
+        centered_text("Not Configured", y, RED, SMALL);
+        y += 28;
+        centered_text("Press red button or", y, LIGHTGREY, TINY);
+        y += 18;
+        centered_text("touch to start WiFi setup", y, LIGHTGREY, TINY);
+    } else {
+        // Status line with colour-coded indicator.
+        color_t sc = websocket_is_connected() ? GREEN
+                   : wifi_is_connected()       ? YELLOW
+                                               : RED;
+        centered_text(wifi_status_str(), y, sc, SMALL);
+        y += 26;
+
+        // SSID.
+        centered_text(cfg.ssid, y, LIGHTGREY, TINY);
+        y += 20;
+
+        // FluidNC IP.
+        std::string ip_str = "FluidNC: ";
+        ip_str += cfg.fluidnc_ip;
+        centered_text(ip_str.c_str(), y, LIGHTGREY, TINY);
+        y += 26;
+
+        // Version.
+        std::string ver_str = "Ver ";
+        ver_str += git_info;
+        centered_text(ver_str.c_str(), y, DARKGREY, TINY);
+        y += 22;
+
+        centered_text("Red btn / touch: AP setup", y, DARKGREY, TINY);
+    }
+
+    drawButtonLegends("AP Setup", "Restart", "Menu");
+}
+
+void WiFiSetupScene::reDisplay() {
+    background();
+    drawStatus();
+    drawMenuTitle(name());
+
+    if (wifi_in_ap_mode()) {
+        drawApView();
+    } else {
+        drawConnectedView();
+    }
+
+    drawError();
+    refreshDisplay();
+}
+
+WiFiSetupScene wifiSetupScene;
+
+#endif  // ARDUINO

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -13,13 +13,13 @@
 #include "Button.h"
 #include "DisplaySettingsScene.h"
 
-extern Scene     menuScene;
+extern Scene       menuScene;
 extern const char* git_info;
 
 // ─── Geometry ─────────────────────────────────────────────────────────────────
 
-static constexpr int BX = 20,  BY  = 28,  BW  = 200, BH  = 34;  // status badge
-static constexpr int CX = 15,  CW  = 210, CH  = 28,  CI  = 8;   // info cards
+static constexpr int BX = 20, BY = 28, BW = 200, BH = 34;       // status badge
+static constexpr int CX = 15, CW = 210, CH = 28, CI = 8;        // info cards
 static constexpr int SBX = 20, SBY = 166, SBW = 200, SBH = 36;  // switch button
 
 static constexpr int CARD_Y0    = 68;
@@ -30,7 +30,7 @@ static constexpr int CARD_PITCH = CH + 4;  // 32 px per card row
 static void drawCard(int y, const char* label, const char* value, int val_color = WHITE) {
     drawOutlinedRect(CX, y, CW, CH, NAVY, WHITE);
     int mid = y + CH / 2 + 2;
-    text(label, CX + CI,      mid, DARKGREY,  TINY,  middle_left);
+    text(label, CX + CI, mid, DARKGREY, TINY, middle_left);
     text(value, CX + CW - CI, mid, val_color, SMALL, middle_right);
 }
 
@@ -120,13 +120,13 @@ void WiFiSetupScene::drawApView() {
 
     y += line_height;
     drawRect(40, y - 2, 160, 1, 0, DARKGREY);  // divider
-    
+
     // IP section
     y += line_height + 8;
     centered_text("Open Browser To:", y, LIGHTGREY, TINY);
     y += line_height;
     centered_text("192.168.4.1", y, GREEN, SMALL);
-    
+
     // ── Button legends ────────────────────────────────────────────────────────
     drawButtonLegends("Stop AP", "Restart", "Exit");
 }
@@ -136,40 +136,44 @@ void WiFiSetupScene::drawSettingsView() {
     WiFiConfig cfg       = wifi_load_config();
 
     // ── Status badge ──────────────────────────────────────────────────────────
-    int        badge_fill;
-    int        badge_text = BLACK;
+    int         badge_fill;
+    int         badge_outline;
+    int         badge_text = BLACK;
     const char* badge_label;
 
     if (uart_mode) {
-        badge_fill  = BLUE;
-        badge_label = "UART Mode";
-        badge_text  = WHITE;
+        badge_fill    = 0x001a4d;
+        badge_outline = 0x4da6ff;
+        badge_label   = "UART Mode";
+        badge_text    = 0x4da6ff;
     } else if (!cfg.valid) {
-        badge_fill  = RED;
-        badge_label = "Not Configured";
-        badge_text  = WHITE;
+        badge_fill    = 0x4d0000;
+        badge_outline = 0xe02b2b;
+        badge_label   = "Not Configured";
+        badge_text    = 0xe02b2b;
     } else {
-        bool ws_ok  = websocket_is_connected();
-        bool wf_ok  = wifi_is_connected();
-        badge_fill  = ws_ok ? GREEN : wf_ok ? YELLOW : RED;
-        badge_label = wifi_status_str();
+        bool ws_ok    = websocket_is_connected();
+        bool wf_ok    = wifi_is_connected();
+        badge_fill    = ws_ok ? 0x003300 : wf_ok ? YELLOW : RED;
+        badge_outline = ws_ok ? 0x66ff66 : wf_ok ? 0xccff00 : 0Xe02b67;
+        badge_label   = wifi_status_str();
     }
-    
+
     // Draw badge with padding
-    drawOutlinedRect(BX - 5, BY - 3, BW + 10, BH + 6, badge_fill, badge_fill);
+    drawOutlinedRect(BX - 5, BY - 3, BW + 10, BH + 6, badge_fill, badge_outline);
     centered_text(badge_label, BY + BH / 2 + 3, badge_text, SMALL);
 
     // ── Info section ──────────────────────────────────────────────────────────
-    int y = CARD_Y0 + 10;
+    int y           = CARD_Y0 + 10;
     int line_height = 16;
 
     if (uart_mode) {
         // UART info
-        y += line_height;
+        y += line_height + 6;
         drawRect(40, y - 2, 160, 1, 0, DARKGREY);  // divider
-        y += 12;
-        centered_text("1 Mbaud", y, CYAN, SMALL);
         y += line_height;
+        centered_text("1 Mbaud", y, 0xe02b2b, SMALL);
+        y += line_height + 2;
         centered_text("Wired UART", y, WHITE, TINY);
     } else if (cfg.valid) {
         // WiFi info
@@ -180,7 +184,7 @@ void WiFiSetupScene::drawSettingsView() {
         centered_text(cfg.ssid, y, WHITE, SMALL);
         y += line_height;
         centered_text(cfg.fluidnc_ip, y, LIGHTGREY, TINY);
-        
+
         // Signal strength with visual indicator
         y += 16;
         int bars = wifi_signal_bars();
@@ -190,23 +194,23 @@ void WiFiSetupScene::drawSettingsView() {
         else if (bars == 3) { bars_str = "●●●○○"; bar_color = YELLOW; }
         else if (bars == 2) { bars_str = "●●○○○"; bar_color = YELLOW; }
         else if (bars == 1) { bars_str = "●○○○○"; bar_color = RED; }
-        
+
         centered_text(bars_str, y, bar_color, SMALL);
     } else {
         // No config
         y += line_height;
-        centered_text("Press Green button", y, ORANGE, TINY);
+        centered_text("Press green button", y, 0xe02b2b, TINY);
         y += line_height;
-        centered_text("to setup WiFi", y, ORANGE, TINY);
+        centered_text("to setup WiFi", y, 0xe02b2b, TINY);
     }
 
     // ── Mode-switch button ────────────────────────────────────────────────────
     {
-        const char* sw_label = uart_mode ? "Switch to WiFi" : "Switch to UART";
-        int         sw_color = uart_mode ? GREEN : BLUE;
-        
-        modeSwitchBtn.set(SBX, SBY, SBW, SBH, sw_label, NAVY, sw_color, sw_color,
-            [this]() { onModeSwitchButtonPress(); });
+        const char* sw_label      = uart_mode ? "Switch to WiFi" : "Switch to Wired";
+        int         sw_fill       = uart_mode ? 0x003300: 0x001a4d;
+        int         sw_outline    = uart_mode ? 0x66ff66: 0x4da6ff;
+
+        modeSwitchBtn.set(SBX, SBY, SBW, SBH, sw_label, sw_fill, sw_outline, sw_outline, [this]() { onModeSwitchButtonPress(); });
     }
 
     // ── Button legends ────────────────────────────────────────────────────────

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -42,79 +42,80 @@ void WiFiSetupScene::onDialButtonPress() {
 }
 
 void WiFiSetupScene::onTouchClick() {
-    // Same toggle as red button — convenient for single-button displays.
     onRedButtonPress();
 }
 
 // ─── Drawing ──────────────────────────────────────────────────────────────────
 
 void WiFiSetupScene::drawApView() {
-    const int cx = 120;   // horizontal centre for centred text
-    int y = 60;
+    int y = 32;
 
     centered_text("AP Mode Active", y, YELLOW, SMALL);
-    y += 26;
+    y += 28;
 
-    centered_text("Connect your device to:", y, LIGHTGREY, TINY);
-    y += 20;
-    centered_text(wifi_ap_ssid(), y, WHITE, SMALL);
-    y += 26;
-
-    centered_text("Then open a browser at:", y, LIGHTGREY, TINY);
-    y += 20;
-    centered_text("192.168.4.1", y, GREEN, SMALL);
-    y += 26;
-
-    centered_text("Fill in the form to", y, LIGHTGREY, TINY);
+    centered_text("Connect your device to:", y, DARKGREY, TINY);
     y += 18;
-    centered_text("configure WiFi + FluidNC", y, LIGHTGREY, TINY);
+    centered_text(wifi_ap_ssid(), y, WHITE, SMALL);
+    y += 28;
+
+    centered_text("Then open a browser at:", y, DARKGREY, TINY);
+    y += 18;
+    centered_text("192.168.4.1", y, GREEN, SMALL);
+    y += 28;
+
+    centered_text("Fill in WiFi SSID,", y, LIGHTGREY, TINY);
+    y += 16;
+    centered_text("password + FluidNC IP", y, LIGHTGREY, TINY);
+    y += 16;
+    centered_text("then press Save", y, LIGHTGREY, TINY);
 
     drawButtonLegends("Stop AP", "Restart", "Menu");
 }
 
 void WiFiSetupScene::drawConnectedView() {
-    WiFiConfig cfg  = wifi_load_config();
-    int        y    = 58;
+    WiFiConfig cfg = wifi_load_config();
 
     if (!cfg.valid) {
-        centered_text("Not Configured", y, RED, SMALL);
-        y += 28;
-        centered_text("Press red button or", y, LIGHTGREY, TINY);
-        y += 18;
-        centered_text("touch to start WiFi setup", y, LIGHTGREY, TINY);
-    } else {
-        // Status line with colour-coded indicator.
-        color_t sc = websocket_is_connected() ? GREEN
-                   : wifi_is_connected()       ? YELLOW
-                                               : RED;
-        centered_text(wifi_status_str(), y, sc, SMALL);
-        y += 26;
-
-        // SSID.
-        centered_text(cfg.ssid, y, LIGHTGREY, TINY);
-        y += 20;
-
-        // FluidNC IP.
-        std::string ip_str = "FluidNC: ";
-        ip_str += cfg.fluidnc_ip;
-        centered_text(ip_str.c_str(), y, LIGHTGREY, TINY);
-        y += 26;
-
-        // Version.
-        std::string ver_str = "Ver ";
-        ver_str += git_info;
-        centered_text(ver_str.c_str(), y, DARKGREY, TINY);
-        y += 22;
-
-        centered_text("Red btn / touch: AP setup", y, DARKGREY, TINY);
+        centered_text("Not Configured", 90, RED, SMALL);
+        centered_text("Press red button or", 120, LIGHTGREY, TINY);
+        centered_text("touch to start WiFi setup", 138, LIGHTGREY, TINY);
+        drawButtonLegends("AP Setup", "Restart", "Menu");
+        return;
     }
+
+    // ── Status badge ──────────────────────────────────────────────────────────
+    bool ws_ok       = websocket_is_connected();
+    bool wf_ok       = wifi_is_connected();
+    int  badge_color = ws_ok ? GREEN : wf_ok ? YELLOW : RED;
+
+    // Filled rounded-rect badge with the connection status centred inside.
+    static constexpr int BW = 140, BH = 30, BY = 30;
+    drawRect((240 - BW) / 2, BY, BW, BH, 8, badge_color);
+    centered_text(wifi_status_str(), BY + BH / 2 + 3, BLACK, SMALL);
+
+    // ── Info rows ─────────────────────────────────────────────────────────────
+    // Each row: small DARKGREY label above a larger WHITE value.
+    centered_text("Network", 72, DARKGREY, TINY);
+    centered_text(cfg.ssid, 88, WHITE, SMALL);
+
+    centered_text("FluidNC IP", 112, DARKGREY, TINY);
+    centered_text(cfg.fluidnc_ip, 128, WHITE, SMALL);
+
+    // ── Machine state badge (only when WebSocket is live) ─────────────────────
+    if (ws_ok) {
+        drawStatusTiny(150);
+    }
+
+    // ── Footer ────────────────────────────────────────────────────────────────
+    std::string ver_str = "Ver ";
+    ver_str += git_info;
+    centered_text(ver_str.c_str(), 182, DARKGREY, TINY);
 
     drawButtonLegends("AP Setup", "Restart", "Menu");
 }
 
 void WiFiSetupScene::reDisplay() {
     background();
-    drawStatus();
     drawMenuTitle(name());
 
     if (wifi_in_ap_mode()) {

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -11,8 +11,41 @@
 #include "Menu.h"
 #include "System.h"
 
-extern Scene menuScene;
+extern Scene     menuScene;
 extern const char* git_info;
+
+// Card geometry shared by connected- and AP-views.
+static constexpr int CX = 15;   // card left edge
+static constexpr int CW = 210;  // card widt
+static constexpr int CH = 26;   // card height
+static constexpr int CI = 7;    // card text inset from each side
+
+// Badge geometry (status pill at top of content area).
+static constexpr int BX = 50;   // badge left edge
+static constexpr int BW = 140;  // badge width
+static constexpr int BH = 34;   // badge height
+static constexpr int BY = 28;   // badge top
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+static void drawCard(int y, const char* label, const char* value,
+                     int value_color = WHITE) {
+    drawOutlinedRect(CX, y, CW, CH, NAVY, WHITE);
+    int mid = y + CH / 2 + 2;
+    text(label, CX + CI,      mid, DARKGREY, TINY,  middle_left);
+    text(value, CX + CW - CI, mid, value_color, SMALL, middle_right);
+}
+
+static void drawCardAuto(int y, const char* label, const char* value,
+                         int value_color = WHITE) {
+    drawOutlinedRect(CX, y, CW, CH, NAVY, WHITE);
+    int mid = y + CH / 2 + 2;
+    text(label, CX + CI, mid, DARKGREY, TINY, middle_left);
+    // Auto-fit so long SSIDs shrink instead of overflowing.
+    static constexpr int VALUE_W = 130;
+    auto_text(std::string(value), CX + CW - CI, mid, VALUE_W,
+              value_color, SMALL, middle_right);
+}
 
 // ─── Event handlers ───────────────────────────────────────────────────────────
 
@@ -48,26 +81,23 @@ void WiFiSetupScene::onTouchClick() {
 // ─── Drawing ──────────────────────────────────────────────────────────────────
 
 void WiFiSetupScene::drawApView() {
-    int y = 32;
+    // ── AP status badge ────────────────────────────────────────────────────────
+    drawOutlinedRect(BX, BY, BW, BH, 0x8400 /* dark orange */, WHITE);
+    centered_text("AP Mode Active", BY + BH / 2 + 3, WHITE, SMALL);
 
-    centered_text("AP Mode Active", y, YELLOW, SMALL);
-    y += 28;
+    // ── Info cards ────────────────────────────────────────────────────────────
+    int y = 70;
+    drawCard(y, "Connect to", wifi_ap_ssid(), CYAN);
+    y += CH + 4;
+    drawCard(y, "Then open", "192.168.4.1", GREEN);
+    y += CH + 14;
 
-    centered_text("Connect your device to:", y, DARKGREY, TINY);
-    y += 18;
-    centered_text(wifi_ap_ssid(), y, WHITE, SMALL);
-    y += 28;
-
-    centered_text("Then open a browser at:", y, DARKGREY, TINY);
-    y += 18;
-    centered_text("192.168.4.1", y, GREEN, SMALL);
-    y += 28;
-
-    centered_text("Fill in WiFi SSID,", y, LIGHTGREY, TINY);
+    // ── Instructions ─────────────────────────────────────────────────────────
+    centered_text("Browse to the IP above,", y, LIGHTGREY, TINY);
     y += 16;
-    centered_text("password + FluidNC IP", y, LIGHTGREY, TINY);
+    centered_text("fill in WiFi + FluidNC IP,", y, LIGHTGREY, TINY);
     y += 16;
-    centered_text("then press Save", y, LIGHTGREY, TINY);
+    centered_text("then press Save.", y, LIGHTGREY, TINY);
 
     drawButtonLegends("Stop AP", "Restart", "Menu");
 }
@@ -76,9 +106,13 @@ void WiFiSetupScene::drawConnectedView() {
     WiFiConfig cfg = wifi_load_config();
 
     if (!cfg.valid) {
-        centered_text("Not Configured", 90, RED, SMALL);
-        centered_text("Press red button or", 120, LIGHTGREY, TINY);
-        centered_text("touch to start WiFi setup", 138, LIGHTGREY, TINY);
+        // ── Not configured ─────────────────────────────────────────────────────
+        drawOutlinedRect(BX, BY, BW, BH, RED, WHITE);
+        centered_text("Not Configured", BY + BH / 2 + 3, WHITE, SMALL);
+
+        centered_text("Press Red or touch to", 112, LIGHTGREY, TINY);
+        centered_text("start WiFi setup.", 130, LIGHTGREY, TINY);
+
         drawButtonLegends("AP Setup", "Restart", "Menu");
         return;
     }
@@ -86,30 +120,28 @@ void WiFiSetupScene::drawConnectedView() {
     // ── Status badge ──────────────────────────────────────────────────────────
     bool ws_ok       = websocket_is_connected();
     bool wf_ok       = wifi_is_connected();
-    int  badge_color = ws_ok ? GREEN : wf_ok ? YELLOW : RED;
+    int  badge_fill  = ws_ok ? GREEN : wf_ok ? YELLOW : RED;
+    int  badge_text  = BLACK;
 
-    // Filled rounded-rect badge with the connection status centred inside.
-    static constexpr int BW = 140, BH = 30, BY = 30;
-    drawRect((240 - BW) / 2, BY, BW, BH, 8, badge_color);
-    centered_text(wifi_status_str(), BY + BH / 2 + 3, BLACK, SMALL);
+    drawOutlinedRect(BX, BY, BW, BH, badge_fill, WHITE);
+    centered_text(wifi_status_str(), BY + BH / 2 + 3, badge_text, SMALL);
 
-    // ── Info rows ─────────────────────────────────────────────────────────────
-    // Each row: small DARKGREY label above a larger WHITE value.
-    centered_text("Network", 72, DARKGREY, TINY);
-    centered_text(cfg.ssid, 88, WHITE, SMALL);
-
-    centered_text("FluidNC IP", 112, DARKGREY, TINY);
-    centered_text(cfg.fluidnc_ip, 128, WHITE, SMALL);
+    // ── Info cards ────────────────────────────────────────────────────────────
+    int y = 70;
+    drawCardAuto(y, "Network", cfg.ssid);
+    y += CH + 4;
+    drawCard(y, "FluidNC IP", cfg.fluidnc_ip);
+    y += CH + 6;
 
     // ── Machine state badge (only when WebSocket is live) ─────────────────────
     if (ws_ok) {
-        drawStatusTiny(150);
+        drawStatusTiny(y);
     }
 
     // ── Footer ────────────────────────────────────────────────────────────────
-    std::string ver_str = "Ver ";
-    ver_str += git_info;
-    centered_text(ver_str.c_str(), 182, DARKGREY, TINY);
+    std::string ver = "Ver ";
+    ver += git_info;
+    centered_text(ver.c_str(), 182, DARKGREY, TINY);
 
     drawButtonLegends("AP Setup", "Restart", "Menu");
 }
@@ -117,6 +149,9 @@ void WiFiSetupScene::drawConnectedView() {
 void WiFiSetupScene::reDisplay() {
     background();
     drawMenuTitle(name());
+
+    // divider
+    drawRect(55, 22, 130, 1, 0, DARKGREY);
 
     if (wifi_in_ap_mode()) {
         drawApView();

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -133,12 +133,13 @@ void WiFiSetupScene::drawApView() {
 void WiFiSetupScene::drawSettingsView() {
     bool       uart_mode = wifi_use_uart_mode();
     WiFiConfig cfg       = wifi_load_config();
+    bool       ws_ok     = websocket_is_connected();
+    bool       wf_ok     = wifi_is_connected();
 
     // ── Status badge ──────────────────────────────────────────────────────────
     int         badge_fill;
     int         badge_outline;
-    int         badge_text = BLACK;
-    fontnum_t   badge_label_size = SMALL;
+    int         badge_text;
     const char* badge_label;
 
     if (uart_mode) {
@@ -151,58 +152,71 @@ void WiFiSetupScene::drawSettingsView() {
         badge_outline = 0xe02b2b;
         badge_label   = "Not Configured";
         badge_text    = 0xe02b2b;
+    } else if (ws_ok) {
+        badge_fill    = 0x003300;
+        badge_outline = 0x66ff66;
+        badge_label   = "Connected";
+        badge_text    = BLACK;
+    } else if (wf_ok) {
+        // WiFi up — waiting for FluidNC WebSocket
+        static const char* nc_frames[] = { "FluidNC", "FluidNC.", "FluidNC..", "FluidNC..." };
+        badge_fill    = 0x332200;
+        badge_outline = YELLOW;
+        badge_label   = nc_frames[(millis() / 400) % 4];
+        badge_text    = YELLOW;
     } else {
-        bool ws_ok          = websocket_is_connected();
-        bool wf_ok          = wifi_is_connected();
-        badge_fill          = ws_ok ? 0x003300 : wf_ok ? YELLOW : RED;
-        badge_outline       = ws_ok ? 0x66ff66 : wf_ok ? 0xccff00 : 0Xe02b67;
-        badge_label         = wifi_status_str();
-        badge_label_size    = wifi_not_ready() ? TINY : SMALL;
+        // WiFi not yet connected
+        static const char* wifi_frames[] = { "WiFi", "WiFi.", "WiFi..", "WiFi..." };
+        badge_fill    = 0x2a0000;
+        badge_outline = 0xe02b2b;
+        badge_label   = wifi_frames[(millis() / 400) % 4];
+        badge_text    = WHITE;
     }
 
-    // Draw badge with padding
     drawOutlinedRect(BX - 5, BY - 3, BW + 10, BH + 6, badge_fill, badge_outline);
-    centered_text(badge_label, BY + BH / 2 + 3, badge_text, badge_label_size);
+    centered_text(badge_label, BY + BH / 2 + 3, badge_text, SMALL);
 
     // ── Info section ──────────────────────────────────────────────────────────
-    int y           = CARD_Y0 + 10;
-    int line_height = 16;
+    int y = CARD_Y0;
 
     if (uart_mode) {
-        // UART info
-        y += line_height + 6;
-        drawRect(40, y - 2, 160, 1, 0, DARKGREY);  // divider
-        y += line_height;
+        y += 14;
         centered_text("1 Mbaud", y, 0xe02b2b, SMALL);
-        y += line_height + 2;
+        y += 20;
         centered_text("Wired UART", y, WHITE, TINY);
-    } else if (cfg.valid) {
-        // WiFi info
-        centered_text("Connected Network", y, LIGHTGREY, TINY);
-        y += line_height;
-        drawRect(40, y - 2, 160, 1, 0, DARKGREY);  // divider
-        y += 12;
-        centered_text(cfg.ssid, y, WHITE, SMALL);
-        y += line_height;
-        centered_text(cfg.fluidnc_ip, y, LIGHTGREY, TINY);
-
-        // Signal strength with visual indicator
-        y += 16;
-        int bars = wifi_signal_bars();
-        const char* bars_str = "○○○○○";
-        int bar_color = RED;
-        if (bars >= 4) { bars_str = "●●●●●"; bar_color = GREEN; }
-        else if (bars == 3) { bars_str = "●●●○○"; bar_color = YELLOW; }
-        else if (bars == 2) { bars_str = "●●○○○"; bar_color = YELLOW; }
-        else if (bars == 1) { bars_str = "●○○○○"; bar_color = RED; }
-
-        centered_text(bars_str, y, bar_color, SMALL);
-    } else {
-        // No config
-        y += line_height;
+    } else if (!cfg.valid) {
+        y += 14;
         centered_text("Press green button", y, 0xe02b2b, TINY);
-        y += line_height;
+        y += 18;
         centered_text("to setup WiFi", y, 0xe02b2b, TINY);
+    } else {
+        // Network label + SSID — always visible so the user knows what we're connecting to
+        centered_text("Network", y, DARKGREY, TINY);
+        y += 16;
+        centered_text(cfg.ssid, y, WHITE, SMALL);
+        y += 22;
+
+        drawRect(40, y, 160, 1, 0, DARKGREY);  // divider
+        y += 14;
+
+        // FluidNC label + IP, coloured by connection phase
+        centered_text("FluidNC", y, DARKGREY, TINY);
+        y += 16;
+        int ip_color = ws_ok ? GREEN : wf_ok ? YELLOW : LIGHTGREY;
+        centered_text(cfg.fluidnc_ip, y, ip_color, SMALL);
+        y += 22;
+
+        if (ws_ok) {
+            // Signal strength — only meaningful once fully connected
+            int         bars     = wifi_signal_bars();
+            const char* bars_str = "○○○○○";
+            int         bar_color = RED;
+            if (bars >= 4)      { bars_str = "●●●●●"; bar_color = GREEN; }
+            else if (bars == 3) { bars_str = "●●●○○"; bar_color = YELLOW; }
+            else if (bars == 2) { bars_str = "●●○○○"; bar_color = YELLOW; }
+            else if (bars == 1) { bars_str = "●○○○○"; bar_color = RED; }
+            centered_text(bars_str, y, bar_color, SMALL);
+        }
     }
 
     // ── Mode-switch button ────────────────────────────────────────────────────

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -74,7 +74,8 @@ void WiFiSetupScene::onModeSwitchButtonPress() {
 
 void WiFiSetupScene::onRedButtonPress() {
     if (wifi_in_ap_mode()) {
-        wifi_stop_ap_and_restart();
+        wifi_stop_ap();
+        reDisplay();
     } else {
         activate_scene(&menuScene);
     }
@@ -91,12 +92,7 @@ void WiFiSetupScene::onGreenButtonPress() {
 }
 
 void WiFiSetupScene::onDialButtonPress() {
-    if (wifi_in_ap_mode()) {
-        // Stop AP without restarting — drop back to the settings view so the
-        // user can see the "Switch to Wired" button and choose a transport.
-        wifi_stop_ap();
-        reDisplay();
-    } else {
+    if (!wifi_in_ap_mode()) {
         activate_scene(&displaySettingsScene);
     }
 }
@@ -131,7 +127,7 @@ void WiFiSetupScene::drawApView() {
     centered_text("192.168.4.1", y, GREEN, SMALL);
 
     // ── Button legends ────────────────────────────────────────────────────────
-    drawButtonLegends("Stop AP", "Restart", "Exit");
+    drawButtonLegends("Exit", "Restart", "");
 }
 
 void WiFiSetupScene::drawSettingsView() {

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -75,7 +75,7 @@ void WiFiSetupScene::onRedButtonPress() {
     if (wifi_in_ap_mode()) {
         wifi_stop_ap_and_restart();
     } else {
-        switchModeAndRestart();
+        activate_scene(&menuScene);
     }
 }
 
@@ -105,26 +105,25 @@ void WiFiSetupScene::drawApView() {
     centered_text("AP Setup Mode", BY + BH / 2 + 3, WHITE, SMALL);
 
     // ── AP Info ────────────────────────────────────────────────────────────────
-    int y = CARD_Y0 + 10;
+    int y = CARD_Y0 + 14;
     int line_height = 24;
 
     // SSID section
-    centered_text("Connect to Network", y, LIGHTGREY, TINY);
+    centered_text("Connect to SSID:", y, LIGHTGREY, TINY);
+    y += line_height;
+    centered_text(wifi_ap_ssid(), y, CYAN, SMALL);
+
     y += line_height;
     drawRect(40, y - 2, 160, 1, 0, DARKGREY);  // divider
-    y += 12;
-    centered_text(wifi_ap_ssid(), y, CYAN, SMALL);
     
     // IP section
     y += line_height + 8;
-    centered_text("Open Browser", y, LIGHTGREY, TINY);
+    centered_text("Open Browser To:", y, LIGHTGREY, TINY);
     y += line_height;
-    drawRect(40, y - 2, 160, 1, 0, DARKGREY);  // divider
-    y += 12;
     centered_text("192.168.4.1", y, GREEN, SMALL);
     
     // ── Button legends ────────────────────────────────────────────────────────
-    drawButtonLegends("Stop AP", "Restart", "Menu");
+    drawButtonLegends("Stop AP", "Restart", "Exit");
 }
 
 void WiFiSetupScene::drawSettingsView() {
@@ -157,11 +156,10 @@ void WiFiSetupScene::drawSettingsView() {
 
     // ── Info section ──────────────────────────────────────────────────────────
     int y = CARD_Y0 + 10;
-    int line_height = 24;
+    int line_height = 16;
 
     if (uart_mode) {
         // UART info
-        centered_text("Serial Connection", y, LIGHTGREY, TINY);
         y += line_height;
         drawRect(40, y - 2, 160, 1, 0, DARKGREY);  // divider
         y += 12;
@@ -191,12 +189,10 @@ void WiFiSetupScene::drawSettingsView() {
         centered_text(bars_str, y, bar_color, SMALL);
     } else {
         // No config
-        y += line_height + 8;
-        drawRect(40, y - 2, 160, 1, 0, DARKGREY);  // divider
-        y += 12;
-        centered_text("Press Green button", y, LIGHTGREY, TINY);
-        y += line_height - 4;
-        centered_text("to configure WiFi", y, LIGHTGREY, TINY);
+        y += line_height;
+        centered_text("Press Green button", y, ORANGE, TINY);
+        y += line_height;
+        centered_text("to setup WiFi", y, ORANGE, TINY);
     }
 
     // ── Mode-switch button ────────────────────────────────────────────────────
@@ -209,14 +205,14 @@ void WiFiSetupScene::drawSettingsView() {
     }
 
     // ── Button legends ────────────────────────────────────────────────────────
-    const char* red_label   = uart_mode ? "WiFi" : "UART";
+    const char* red_label   = "Back";
     const char* green_label = uart_mode ? "Restart" : "Setup";
-    drawButtonLegends(red_label, green_label, "Menu");
+    drawButtonLegends(red_label, green_label, "Info");
 }
 
 void WiFiSetupScene::reDisplay() {
     background();
-    drawMenuTitle(name());
+    centered_text("Connection Settings", 12);
     drawRect(55, 22, 130, 1, 0, DARKGREY);
 
     if (wifi_in_ap_mode()) {

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -92,7 +92,10 @@ void WiFiSetupScene::onGreenButtonPress() {
 
 void WiFiSetupScene::onDialButtonPress() {
     if (wifi_in_ap_mode()) {
-        activate_scene(&menuScene);
+        // Stop AP without restarting — drop back to the settings view so the
+        // user can see the "Switch to Wired" button and choose a transport.
+        wifi_stop_ap();
+        reDisplay();
     } else {
         activate_scene(&displaySettingsScene);
     }

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -191,8 +191,9 @@ void WiFiSetupScene::drawSettingsView() {
         centered_text("to setup WiFi", y, 0xe02b2b, TINY);
     } else {
         // Network label + SSID — always visible so the user knows what we're connecting to
+        y +=10;
         centered_text("Network", y, DARKGREY, TINY);
-        y += 16;
+        y += 20;
         centered_text(cfg.ssid, y, WHITE, SMALL);
         y += 22;
 
@@ -200,8 +201,8 @@ void WiFiSetupScene::drawSettingsView() {
         y += 14;
 
         // FluidNC label + IP, coloured by connection phase
-        centered_text("FluidNC", y, DARKGREY, TINY);
-        y += 16;
+        centered_text("FluidNC Address", y, DARKGREY, TINY);
+        y += 20;
         int ip_color = ws_ok ? GREEN : wf_ok ? YELLOW : LIGHTGREY;
         centered_text(cfg.fluidnc_ip, y, ip_color, SMALL);
         y += 22;
@@ -236,7 +237,18 @@ void WiFiSetupScene::drawSettingsView() {
 
 void WiFiSetupScene::reDisplay() {
     background();
-    centered_text("Connection Settings", 12);
+
+    const char* title;
+    if (wifi_in_ap_mode() || wifi_use_uart_mode() || !wifi_load_config().valid) {
+        title = "Connection Settings";
+    } else if (websocket_is_connected()) {
+        title = "Connection Established";
+    } else if (wifi_is_connected()) {
+        title = " Connecting to FluidNC";
+    } else {
+        title = "Connecting to WiFi";
+    }
+    centered_text(title, 12);
     drawRect(55, 22, 130, 1, 0, DARKGREY);
 
     if (wifi_in_ap_mode()) {

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -10,13 +10,14 @@
 #include "Drawing.h"
 #include "Menu.h"
 #include "System.h"
+#include "Button.h"
 
 extern Scene     menuScene;
 extern const char* git_info;
 
 // ─── Geometry ─────────────────────────────────────────────────────────────────
 
-static constexpr int BX = 50,  BY  = 28,  BW  = 140, BH  = 34;  // status badge
+static constexpr int BX = 20,  BY  = 28,  BW  = 200, BH  = 34;  // status badge
 static constexpr int CX = 15,  CW  = 210, CH  = 28,  CI  = 8;   // info cards
 static constexpr int SBX = 20, SBY = 166, SBW = 200, SBH = 36;  // switch button
 
@@ -62,6 +63,14 @@ void WiFiSetupScene::switchModeAndRestart() {
     ESP.restart();
 }
 
+void WiFiSetupScene::onModeSwitchButtonPress() {
+    if (wifi_in_ap_mode()) {
+        wifi_stop_ap_and_restart();
+    } else {
+        switchModeAndRestart();
+    }
+}
+
 void WiFiSetupScene::onRedButtonPress() {
     if (wifi_in_ap_mode()) {
         wifi_stop_ap_and_restart();
@@ -85,26 +94,36 @@ void WiFiSetupScene::onDialButtonPress() {
 }
 
 void WiFiSetupScene::onTouchClick() {
-    if (wifi_in_ap_mode()) {
-        wifi_stop_ap_and_restart();
-    } else {
-        switchModeAndRestart();
-    }
+    modeSwitchBtn.handleTouch(touchX, touchY);
 }
 
 // ─── Drawing ──────────────────────────────────────────────────────────────────
 
 void WiFiSetupScene::drawApView() {
-    drawOutlinedRect(BX, BY, BW, BH, 0x8400 /* dark orange */, WHITE);
+    // ── Status badge ──────────────────────────────────────────────────────────
+    drawOutlinedRect(BX - 5, BY - 3, BW + 10, BH + 6, 0x8400, 0x8400);  // dark orange
     centered_text("AP Setup Mode", BY + BH / 2 + 3, WHITE, SMALL);
 
-    int y = CARD_Y0;
-    drawCard(y,     "Connect to", wifi_ap_ssid(), CYAN);  y += CARD_PITCH;
-    drawCard(y,     "Browse to",  "192.168.4.1",  GREEN); y += CH + 14;
+    // ── AP Info ────────────────────────────────────────────────────────────────
+    int y = CARD_Y0 + 10;
+    int line_height = 24;
 
-    centered_text("Fill in WiFi + FluidNC IP,", y,      LIGHTGREY, TINY);
-    centered_text("then tap Save.",              y + 16, LIGHTGREY, TINY);
-
+    // SSID section
+    centered_text("Connect to Network", y, LIGHTGREY, TINY);
+    y += line_height;
+    drawRect(40, y - 2, 160, 1, 0, DARKGREY);  // divider
+    y += 12;
+    centered_text(wifi_ap_ssid(), y, CYAN, SMALL);
+    
+    // IP section
+    y += line_height + 8;
+    centered_text("Open Browser", y, LIGHTGREY, TINY);
+    y += line_height;
+    drawRect(40, y - 2, 160, 1, 0, DARKGREY);  // divider
+    y += 12;
+    centered_text("192.168.4.1", y, GREEN, SMALL);
+    
+    // ── Button legends ────────────────────────────────────────────────────────
     drawButtonLegends("Stop AP", "Restart", "Menu");
 }
 
@@ -131,41 +150,67 @@ void WiFiSetupScene::drawSettingsView() {
         badge_fill  = ws_ok ? GREEN : wf_ok ? YELLOW : RED;
         badge_label = wifi_status_str();
     }
-    drawOutlinedRect(BX, BY, BW, BH, badge_fill, WHITE);
+    
+    // Draw badge with padding
+    drawOutlinedRect(BX - 5, BY - 3, BW + 10, BH + 6, badge_fill, badge_fill);
     centered_text(badge_label, BY + BH / 2 + 3, badge_text, SMALL);
 
-    // ── Info cards ────────────────────────────────────────────────────────────
-    int y = CARD_Y0;
+    // ── Info section ──────────────────────────────────────────────────────────
+    int y = CARD_Y0 + 10;
+    int line_height = 24;
 
     if (uart_mode) {
-        drawCard(y, "Baud Rate",  "1 Mbaud", CYAN);  y += CARD_PITCH;
-        drawCard(y, "Transport",  "Wired UART");
+        // UART info
+        centered_text("Serial Connection", y, LIGHTGREY, TINY);
+        y += line_height;
+        drawRect(40, y - 2, 160, 1, 0, DARKGREY);  // divider
+        y += 12;
+        centered_text("1 Mbaud", y, CYAN, SMALL);
+        y += line_height;
+        centered_text("Wired UART", y, WHITE, TINY);
     } else if (cfg.valid) {
-        drawCardAuto(y, "Network",  cfg.ssid);           y += CARD_PITCH;
-        drawCard(y,     "FluidNC",  cfg.fluidnc_ip);     y += CARD_PITCH;
-
-        char sigbuf[24];
-        int  bars = wifi_signal_bars();
-        snprintf(sigbuf, sizeof(sigbuf), "%s (%d/4)", signal_str(bars), bars);
-        drawCard(y, "Signal", sigbuf);
+        // WiFi info
+        centered_text("Connected Network", y, LIGHTGREY, TINY);
+        y += line_height;
+        drawRect(40, y - 2, 160, 1, 0, DARKGREY);  // divider
+        y += 12;
+        centered_text(cfg.ssid, y, WHITE, SMALL);
+        y += line_height;
+        centered_text(cfg.fluidnc_ip, y, LIGHTGREY, TINY);
+        
+        // Signal strength with visual indicator
+        y += 16;
+        int bars = wifi_signal_bars();
+        const char* bars_str = "○○○○○";
+        int bar_color = RED;
+        if (bars >= 4) { bars_str = "●●●●●"; bar_color = GREEN; }
+        else if (bars == 3) { bars_str = "●●●○○"; bar_color = YELLOW; }
+        else if (bars == 2) { bars_str = "●●○○○"; bar_color = YELLOW; }
+        else if (bars == 1) { bars_str = "●○○○○"; bar_color = RED; }
+        
+        centered_text(bars_str, y, bar_color, SMALL);
     } else {
-        // WiFi mode but no credentials stored yet
-        centered_text("No WiFi credentials saved.", CARD_Y0 + 12, LIGHTGREY, SMALL);
-        centered_text("Press Green to run AP Setup", CARD_Y0 + 38, LIGHTGREY, TINY);
-        centered_text("and configure your network.", CARD_Y0 + 54, LIGHTGREY, TINY);
+        // No config
+        y += line_height + 8;
+        drawRect(40, y - 2, 160, 1, 0, DARKGREY);  // divider
+        y += 12;
+        centered_text("Press Green button", y, LIGHTGREY, TINY);
+        y += line_height - 4;
+        centered_text("to configure WiFi", y, LIGHTGREY, TINY);
     }
 
     // ── Mode-switch button ────────────────────────────────────────────────────
     {
         const char* sw_label = uart_mode ? "Switch to WiFi" : "Switch to UART";
         int         sw_color = uart_mode ? GREEN : BLUE;
-        drawOutlinedRect(SBX, SBY, SBW, SBH, NAVY, sw_color);
-        centered_text(sw_label, SBY + SBH / 2 + 3, sw_color, SMALL);
+        
+        modeSwitchBtn.set(SBX, SBY, SBW, SBH, sw_label, NAVY, sw_color, sw_color,
+            [this]() { onModeSwitchButtonPress(); });
     }
 
     // ── Button legends ────────────────────────────────────────────────────────
-    const char* red_label   = uart_mode ? "Use WiFi"  : "Use UART";
-    const char* green_label = uart_mode ? "Restart"   : "AP Setup";
+    const char* red_label   = uart_mode ? "WiFi" : "UART";
+    const char* green_label = uart_mode ? "Restart" : "Setup";
     drawButtonLegends(red_label, green_label, "Menu");
 }
 

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -201,7 +201,7 @@ void WiFiSetupScene::drawSettingsView() {
         centered_text("Network", y, DARKGREY, TINY);
         y += 20;
         centered_text(cfg.ssid, y, WHITE, SMALL);
-        y += 22;
+        y += 20;
 
         drawRect(40, y, 160, 1, 0, DARKGREY);  // divider
         y += 14;

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -132,7 +132,7 @@ void WiFiSetupScene::drawApView() {
 
 void WiFiSetupScene::drawSettingsView() {
     bool       uart_mode = wifi_use_uart_mode();
-    WiFiConfig cfg       = wifi_load_config();
+    WiFiConfig cfg       = wifi_active_config();  // cached — no NVS read on every frame
     bool       ws_ok     = websocket_is_connected();
     bool       wf_ok     = wifi_is_connected();
 
@@ -164,8 +164,14 @@ void WiFiSetupScene::drawSettingsView() {
         badge_outline = YELLOW;
         badge_label   = nc_frames[(millis() / 400) % 4];
         badge_text    = YELLOW;
+    } else if (wifi_last_error()) {
+        // WiFi connection failed (wrong password / network not found)
+        badge_fill    = 0x4d0000;
+        badge_outline = RED;
+        badge_label   = "WiFi Error";
+        badge_text    = WHITE;
     } else {
-        // WiFi not yet connected
+        // WiFi not yet connected — still trying
         static const char* wifi_frames[] = { "WiFi", "WiFi.", "WiFi..", "WiFi..." };
         badge_fill    = 0x2a0000;
         badge_outline = 0xe02b2b;
@@ -200,12 +206,21 @@ void WiFiSetupScene::drawSettingsView() {
         drawRect(40, y, 160, 1, 0, DARKGREY);  // divider
         y += 14;
 
-        // FluidNC label + IP, coloured by connection phase
-        centered_text("FluidNC Address", y, DARKGREY, TINY);
-        y += 20;
-        int ip_color = ws_ok ? GREEN : wf_ok ? YELLOW : LIGHTGREY;
-        centered_text(cfg.fluidnc_ip, y, ip_color, SMALL);
-        y += 22;
+        if (wifi_last_error()) {
+            // Show the failure reason instead of the FluidNC IP
+            centered_text("WiFi Error", y, DARKGREY, TINY);
+            y += 20;
+            centered_text(wifi_last_error(), y, RED, SMALL);
+            y += 20;
+            centered_text("Retrying...", y, 0x888888, TINY);
+        } else {
+            // FluidNC label + IP, coloured by connection phase
+            centered_text("FluidNC Address", y, DARKGREY, TINY);
+            y += 20;
+            int ip_color = ws_ok ? GREEN : wf_ok ? YELLOW : LIGHTGREY;
+            centered_text(cfg.fluidnc_ip, y, ip_color, SMALL);
+            y += 22;
+        }
 
         if (ws_ok) {
             // Signal strength — only meaningful once fully connected
@@ -239,7 +254,7 @@ void WiFiSetupScene::reDisplay() {
     background();
 
     const char* title;
-    if (wifi_in_ap_mode() || wifi_use_uart_mode() || !wifi_load_config().valid) {
+    if (wifi_in_ap_mode() || wifi_use_uart_mode() || !wifi_active_config().valid) {
         title = "Connection Settings";
     } else if (websocket_is_connected()) {
         title = "Connection Established";

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -138,6 +138,7 @@ void WiFiSetupScene::drawSettingsView() {
     int         badge_fill;
     int         badge_outline;
     int         badge_text = BLACK;
+    fontnum_t   badge_label_size = SMALL;
     const char* badge_label;
 
     if (uart_mode) {
@@ -151,16 +152,17 @@ void WiFiSetupScene::drawSettingsView() {
         badge_label   = "Not Configured";
         badge_text    = 0xe02b2b;
     } else {
-        bool ws_ok    = websocket_is_connected();
-        bool wf_ok    = wifi_is_connected();
-        badge_fill    = ws_ok ? 0x003300 : wf_ok ? YELLOW : RED;
-        badge_outline = ws_ok ? 0x66ff66 : wf_ok ? 0xccff00 : 0Xe02b67;
-        badge_label   = wifi_status_str();
+        bool ws_ok          = websocket_is_connected();
+        bool wf_ok          = wifi_is_connected();
+        badge_fill          = ws_ok ? 0x003300 : wf_ok ? YELLOW : RED;
+        badge_outline       = ws_ok ? 0x66ff66 : wf_ok ? 0xccff00 : 0Xe02b67;
+        badge_label         = wifi_status_str();
+        badge_label_size    = wifi_not_ready() ? TINY : SMALL;
     }
 
     // Draw badge with padding
     drawOutlinedRect(BX - 5, BY - 3, BW + 10, BH + 6, badge_fill, badge_outline);
-    centered_text(badge_label, BY + BH / 2 + 3, badge_text, SMALL);
+    centered_text(badge_label, BY + BH / 2 + 3, badge_text, badge_label_size);
 
     // ── Info section ──────────────────────────────────────────────────────────
     int y           = CARD_Y0 + 10;

--- a/src/WiFiSetupScene.h
+++ b/src/WiFiSetupScene.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#ifdef ARDUINO
+
+#include "Scene.h"
+
+class WiFiSetupScene : public Scene {
+public:
+    WiFiSetupScene() : Scene("WiFi") {}
+
+    void onEntry(void* arg = nullptr) override;
+    void onRedButtonPress() override;    // Start / stop AP setup
+    void onGreenButtonPress() override;  // Restart ESP
+    void onDialButtonPress() override;   // Back to main menu
+    void onTouchClick() override;        // Same as red button
+    void onStateChange(state_t) override;
+    void reDisplay() override;
+
+private:
+    void drawConnectedView();
+    void drawApView();
+};
+
+extern WiFiSetupScene wifiSetupScene;
+
+#endif  // ARDUINO

--- a/src/WiFiSetupScene.h
+++ b/src/WiFiSetupScene.h
@@ -6,18 +6,19 @@
 
 class WiFiSetupScene : public Scene {
 public:
-    WiFiSetupScene() : Scene("WiFi") {}
+    WiFiSetupScene() : Scene("Settings") {}
 
     void onEntry(void* arg = nullptr) override;
-    void onRedButtonPress() override;    // Start / stop AP setup
-    void onGreenButtonPress() override;  // Restart ESP
-    void onDialButtonPress() override;   // Back to main menu
-    void onTouchClick() override;        // Same as red button
+    void onRedButtonPress() override;    // Switch transport (or stop AP)
+    void onGreenButtonPress() override;  // AP Setup / Restart
+    void onDialButtonPress() override;   // Back to menu
+    void onTouchClick() override;        // Same as Red
     void onStateChange(state_t) override;
     void reDisplay() override;
 
 private:
-    void drawConnectedView();
+    void switchModeAndRestart();
+    void drawSettingsView();
     void drawApView();
 };
 

--- a/src/WiFiSetupScene.h
+++ b/src/WiFiSetupScene.h
@@ -12,7 +12,7 @@ public:
     void onEntry(void* arg = nullptr) override;
     void onRedButtonPress() override;    // Switch transport (or stop AP)
     void onGreenButtonPress() override;  // AP Setup / Restart
-    void onDialButtonPress() override;   // Back to menu
+    void onDialButtonPress() override;   // Display settings
     void onTouchClick() override;        // Interactive button
     void onStateChange(state_t) override;
     void reDisplay() override;

--- a/src/WiFiSetupScene.h
+++ b/src/WiFiSetupScene.h
@@ -3,6 +3,7 @@
 #ifdef ARDUINO
 
 #include "Scene.h"
+#include "Button.h"
 
 class WiFiSetupScene : public Scene {
 public:
@@ -12,14 +13,16 @@ public:
     void onRedButtonPress() override;    // Switch transport (or stop AP)
     void onGreenButtonPress() override;  // AP Setup / Restart
     void onDialButtonPress() override;   // Back to menu
-    void onTouchClick() override;        // Same as Red
+    void onTouchClick() override;        // Interactive button
     void onStateChange(state_t) override;
     void reDisplay() override;
 
 private:
     void switchModeAndRestart();
+    void onModeSwitchButtonPress();
     void drawSettingsView();
     void drawApView();
+    Button modeSwitchBtn;
 };
 
 extern WiFiSetupScene wifiSetupScene;

--- a/src/ardmain.cpp
+++ b/src/ardmain.cpp
@@ -21,6 +21,25 @@ extern const char* git_info;
 
 extern AboutScene aboutScene;
 
+#ifdef USE_WIFI
+extern Scene menuScene;
+extern WiFiSetupScene wifiSetupScene;
+
+void first_boot_complete() {
+    _first_boot_active = false;
+
+    if (wifi_use_uart_mode()) {
+        fnc_realtime(StatusReport);
+        activate_scene(&menuScene);
+    } else {
+        // WiFi mode — credentials don't exist yet on a true first boot,
+        // so go straight to the WiFi setup scene.  wifi_init() will run
+        // on the next loop() iteration and auto-start the AP.
+        activate_scene(&wifiSetupScene);
+    }
+}
+#endif
+
 void setup() {
     init_system();
 
@@ -51,8 +70,8 @@ void setup() {
 #elif defined(USE_WIFI)
     // On first boot (no transport mode saved yet) show the setup wizard
     // immediately — before the main menu — so the user is never silently
-    // dropped into WiFi mode.  The wizard restarts the device on selection,
-    // so wifi_init() is deferred until the next normal boot.
+    // dropped into WiFi mode.  first_boot_complete() handles the
+    // transition once the user picks a transport.
     if (wifi_is_first_boot()) {
         _first_boot_active = true;
         activate_scene(&firstBootScene);

--- a/src/ardmain.cpp
+++ b/src/ardmain.cpp
@@ -46,8 +46,8 @@ void setup() {
 
     // For debugging certain views without setting WiFi/UART transports
 #ifdef DEV_SKIP_TO_SCENE
-    extern Scene multiJogScene;
-    activate_scene(&multiJogScene);
+    extern Scene DEV_SKIP_TO_SCENE;
+    activate_scene(&DEV_SKIP_TO_SCENE);
 #elif defined(USE_WIFI)
     // On first boot (no transport mode saved yet) show the setup wizard
     // immediately — before the main menu — so the user is never silently

--- a/src/ardmain.cpp
+++ b/src/ardmain.cpp
@@ -9,6 +9,9 @@
 #ifdef USE_WIFI
 #    include "WiFiConnection.h"
 #    include "WiFiSetupScene.h"
+extern Scene firstBootScene;
+static bool _wifi_initialized  = false;
+static bool _first_boot_active = false;
 #endif
 
 extern void base_display();
@@ -31,30 +34,42 @@ void setup() {
     dbg_printf("FluidNC Pendant %s\n", git_info);
 
 #ifndef USE_WIFI
-    fnc_realtime(StatusReport);  // Activate FluidNC connection via UART
+    fnc_realtime(StatusReport);  // Kick FluidNC into action via UART
+#else
+    if (wifi_use_uart_mode()) {
+        fnc_realtime(StatusReport);  // UART mode in a WiFi build
+    }
 #endif
-
-    // init_file_list();
 
     extern Scene* initMenus();
-    activate_scene(initMenus());
-    // WiFi intentionally NOT started here. Starting WiFi before the first render causes an OOM crash inside new LGFX_Sprite().
-    // wifi_init() will be called on the first loop() iteration instead.
-}
+    Scene* menu = initMenus();
 
 #ifdef USE_WIFI
-static bool _wifi_initialized = false;
+    // On first boot (no transport mode saved yet) show the setup wizard
+    // immediately — before the main menu — so the user is never silently
+    // dropped into WiFi mode.  The wizard restarts the device on selection,
+    // so wifi_init() is deferred until the next normal boot.
+    if (wifi_is_first_boot()) {
+        _first_boot_active = true;
+        activate_scene(&firstBootScene);
+    } else {
+        activate_scene(menu);
+    }
+#else
+    activate_scene(menu);
 #endif
+}
 
 void loop() {
 #ifdef USE_WIFI
-    if (!_wifi_initialized) {
+    if (!_first_boot_active) {
+        if (!_wifi_initialized) {
         // Defer WiFi init until after setup() has returned + 1st render is complete - ensure sprite caches allocate before WiFi consumes heap.
-        _wifi_initialized = true;
-        wifi_init();
-    }
+            _wifi_initialized = true;
+            wifi_init();
+        }
     wifi_poll();
 #endif
-    fnc_poll();         // Handle messages from FluidNC
+    fnc_poll();         // Parse incoming bytes from FluidNC (UART or WebSocket)
     dispatch_events();  // Handle dial, touch, buttons
 }

--- a/src/ardmain.cpp
+++ b/src/ardmain.cpp
@@ -6,6 +6,11 @@
 #include "Scene.h"
 #include "AboutScene.h"
 
+#ifdef USE_WIFI
+#    include "WiFiConnection.h"
+#    include "WiFiSetupScene.h"
+#endif
+
 extern void base_display();
 extern void show_logo();
 
@@ -25,15 +30,31 @@ void setup() {
 
     dbg_printf("FluidNC Pendant %s\n", git_info);
 
-    fnc_realtime(StatusReport);  // Kick FluidNC into action
+#ifndef USE_WIFI
+    fnc_realtime(StatusReport);  // Activate FluidNC connection via UART
+#endif
 
     // init_file_list();
 
     extern Scene* initMenus();
     activate_scene(initMenus());
+    // WiFi intentionally NOT started here. Starting WiFi before the first render causes an OOM crash inside new LGFX_Sprite().
+    // wifi_init() will be called on the first loop() iteration instead.
 }
 
+#ifdef USE_WIFI
+static bool _wifi_initialized = false;
+#endif
+
 void loop() {
+#ifdef USE_WIFI
+    if (!_wifi_initialized) {
+        // Defer WiFi init until after setup() has returned + 1st render is complete - ensure sprite caches allocate before WiFi consumes heap.
+        _wifi_initialized = true;
+        wifi_init();
+    }
+    wifi_poll();
+#endif
     fnc_poll();         // Handle messages from FluidNC
     dispatch_events();  // Handle dial, touch, buttons
 }

--- a/src/ardmain.cpp
+++ b/src/ardmain.cpp
@@ -29,7 +29,7 @@ void setup() {
     show_logo();
     delay_ms(1000);  // view the logo and wait for the debug port to connect
 
-    // base_display();
+    base_display();
 
     dbg_printf("FluidNC Pendant %s\n", git_info);
 

--- a/src/ardmain.cpp
+++ b/src/ardmain.cpp
@@ -44,7 +44,11 @@ void setup() {
     extern Scene* initMenus();
     Scene* menu = initMenus();
 
-#ifdef USE_WIFI
+    // For debugging certain views without setting WiFi/UART transports
+#ifdef DEV_SKIP_TO_SCENE
+    extern Scene multiJogScene;
+    activate_scene(&multiJogScene);
+#elif defined(USE_WIFI)
     // On first boot (no transport mode saved yet) show the setup wizard
     // immediately — before the main menu — so the user is never silently
     // dropped into WiFi mode.  The wizard restarts the device on selection,

--- a/src/ardmain.cpp
+++ b/src/ardmain.cpp
@@ -52,6 +52,11 @@ void setup() {
     if (wifi_is_first_boot()) {
         _first_boot_active = true;
         activate_scene(&firstBootScene);
+    } else if (!wifi_use_uart_mode() && !wifi_load_config().valid) {
+        // WiFi mode selected but no credentials configured yet.
+        // Land in WiFiSetupScene; wifi_init() (deferred to loop) will
+        // auto-start AP so the user can set credentials via browser.
+        activate_scene(&wifiSetupScene);
     } else {
         activate_scene(menu);
     }

--- a/src/ardmain.cpp
+++ b/src/ardmain.cpp
@@ -27,9 +27,9 @@ void setup() {
     display.setBrightness(aboutScene.getBrightness());
 
     show_logo();
-    delay_ms(2000);  // view the logo and wait for the debug port to connect
+    delay_ms(1000);  // view the logo and wait for the debug port to connect
 
-    base_display();
+    // base_display();
 
     dbg_printf("FluidNC Pendant %s\n", git_info);
 
@@ -68,7 +68,8 @@ void loop() {
             _wifi_initialized = true;
             wifi_init();
         }
-    wifi_poll();
+        wifi_poll();
+    }
 #endif
     fnc_poll();         // Parse incoming bytes from FluidNC (UART or WebSocket)
     dispatch_events();  // Handle dial, touch, buttons

--- a/src/sdlmain.c
+++ b/src/sdlmain.c
@@ -7,11 +7,15 @@ extern void loop();
 
 char* comname;
 int   main(int argc, char** argv) {
+#ifdef WINDOWS
     if (argc != 2) {
         printf("Usage: %s COMn\n", argv[0]);
         exit(1);
     }
     comname = argv[1];
+#else
+    comname = (argc >= 2) ? argv[1] : NULL;
+#endif
 
     setup();
 


### PR DESCRIPTION
This adds WiFi support to FluidDial, allowing the pendant to communicate with FluidNC over WebSocket instead of requiring a physical serial cable. Both WiFi and UART modes are fully supported on M5Dial and CYD hardware.

## Features

- **WiFi/UART mode selection** on first boot, with the ability to switch between modes at any time
- **Captive portal** for WiFi configuration — starts an AP named "FluidDial" where users can scan for networks, enter credentials, and set the FluidNC hostname
- **mDNS resolution**
- **WiFi signal strength indicator** on the main menu screen
- **Color-coded connection status** showing WiFi state, WebSocket state, and error details at a glance

## Bug Fixes/Improvements

- **Fix SD card file browsing and macro retrieval** — both now work reliably over WiFi and UART
- **Fix choppy/stalled jogging** — improved jog buffer management eliminates overloading the jog buffer, resulting in smooth jogging over both WiFi and UART
- **Fix alarm handling** — status scene now correctly displays during active alarms, with a confirmation modal for soft resets
- **Fix display orientation screen**

See more details  in the [Wiki page](http://wiki.fluidnc.com/en/hardware/official/FluidDial_Wireless)
