### PR TITLE
Fix residual layout issues on M5 round displays and improve websocket failure handling.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -140,7 +140,7 @@ build_flags = -O0 -xc++ -std=c++17 -lSDL2
   -DMACOS
   -DUSE_M5
   -DUSE_WIFI
-;   -DDEV_SKIP_TO_SCENE=systemScene         ; change to wifiSetupScene, aboutScene, etc.
+  -DDEV_SKIP_TO_SCENE=multiJogScene         ; change to wifiSetupScene, aboutScene, etc.
   -DM5GFX_BOARD=board_M5Dial
   -I"${sysenv.HOMEBREW_PREFIX}/include/SDL2"  ; arm64 Mac (Apple Silicon)
   -L"${sysenv.HOMEBREW_PREFIX}/lib"

--- a/platformio.ini
+++ b/platformio.ini
@@ -140,7 +140,7 @@ build_flags = -O0 -xc++ -std=c++17 -lSDL2
   -DMACOS
   -DUSE_M5
   -DUSE_WIFI
-  -DDEV_SKIP_TO_SCENE=statusScene         ; change to wifiSetupScene, aboutScene, etc.
+;   -DDEV_SKIP_TO_SCENE=firstBootScene         ; change to wifiSetupScene, aboutScene, etc.
   -DM5GFX_BOARD=board_M5Dial
   -I"${sysenv.HOMEBREW_PREFIX}/include/SDL2"  ; arm64 Mac (Apple Silicon)
   -L"${sysenv.HOMEBREW_PREFIX}/lib"

--- a/platformio.ini
+++ b/platformio.ini
@@ -140,7 +140,7 @@ build_flags = -O0 -xc++ -std=c++17 -lSDL2
   -DMACOS
   -DUSE_M5
   -DUSE_WIFI
-  -DDEV_SKIP_TO_SCENE=systemScene         ; change to wifiSetupScene, aboutScene, etc.
+  -DDEV_SKIP_TO_SCENE=statusScene         ; change to wifiSetupScene, aboutScene, etc.
   -DM5GFX_BOARD=board_M5Dial
   -I"${sysenv.HOMEBREW_PREFIX}/include/SDL2"  ; arm64 Mac (Apple Silicon)
   -L"${sysenv.HOMEBREW_PREFIX}/lib"

--- a/platformio.ini
+++ b/platformio.ini
@@ -140,7 +140,7 @@ build_flags = -O0 -xc++ -std=c++17 -lSDL2
   -DMACOS
   -DUSE_M5
   -DUSE_WIFI
-;   -DDEV_SKIP_TO_SCENE=multiJogScene         ; change to wifiSetupScene, aboutScene, etc.
+  -DDEV_SKIP_TO_SCENE=systemScene         ; change to wifiSetupScene, aboutScene, etc.
   -DM5GFX_BOARD=board_M5Dial
   -I"${sysenv.HOMEBREW_PREFIX}/include/SDL2"  ; arm64 Mac (Apple Silicon)
   -L"${sysenv.HOMEBREW_PREFIX}/lib"

--- a/platformio.ini
+++ b/platformio.ini
@@ -140,7 +140,7 @@ build_flags = -O0 -xc++ -std=c++17 -lSDL2
   -DMACOS
   -DUSE_M5
   -DUSE_WIFI
-  -DDEV_SKIP_TO_SCENE=multiJogScene         ; change to wifiSetupScene, aboutScene, etc.
+;   -DDEV_SKIP_TO_SCENE=multiJogScene         ; change to wifiSetupScene, aboutScene, etc.
   -DM5GFX_BOARD=board_M5Dial
   -I"${sysenv.HOMEBREW_PREFIX}/include/SDL2"  ; arm64 Mac (Apple Silicon)
   -L"${sysenv.HOMEBREW_PREFIX}/lib"

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,7 @@ build_flags =
 lib_deps =
     https://github.com/MitchBradley/json-streaming-parser#charp-1.0.2
     https://github.com/MitchBradley/GrblParser#9108f54
-build_src_filter = +<*.c> +<*.h> +<*.cpp> +<*.hpp>  -<System*.cpp> -<Hardware*.cpp> +<System.cpp> -<Touch_Class.cpp>
+build_src_filter = +<*.c> +<*.h> +<*.cpp> +<*.hpp>  -<System*.cpp> -<Hardware*.cpp> +<System.cpp> +<SystemScene.cpp> -<Touch_Class.cpp>
 
 [env:m5dial]
 ; Pendant based on M5Dial
@@ -139,7 +139,8 @@ build_flags = -O0 -xc++ -std=c++17 -lSDL2
   ${common.build_flags}
   -DMACOS
   -DUSE_M5
-  ;-DDEV_SKIP_TO_SCENE=multiJogScene          ; uncomment to test different scenes
+  -DUSE_WIFI
+;   -DDEV_SKIP_TO_SCENE=systemScene         ; change to wifiSetupScene, aboutScene, etc.
   -DM5GFX_BOARD=board_M5Dial
   -I"${sysenv.HOMEBREW_PREFIX}/include/SDL2"  ; arm64 Mac (Apple Silicon)
   -L"${sysenv.HOMEBREW_PREFIX}/lib"

--- a/src/Button.h
+++ b/src/Button.h
@@ -12,6 +12,8 @@ struct Button {
     int         text_color;
     std::function<void()> onPress;
 
+    fontnum_t font = SMALL;
+
     Button() : x(0), y(0), w(0), h(0), label(""), fill_color(NAVY),
                outline_color(WHITE), text_color(WHITE), onPress(nullptr) {}
 
@@ -34,7 +36,7 @@ struct Button {
      */
     void draw() const {
         drawOutlinedRect(x, y, w, h, fill_color, outline_color);
-        centered_text(label, y + h / 2 + 3, text_color, SMALL);
+        centered_text(label, y + h / 2 + 3, text_color, font);
     }
 
     /**

--- a/src/ConfirmScene.cpp
+++ b/src/ConfirmScene.cpp
@@ -10,7 +10,9 @@ public:
     void reDisplay() {
         background();
 
-        drawOutlinedRect(10, 80, 230, 100, 0x001a4d, 0x4da6ff);
+        if (!round_display) {
+            drawOutlinedRect(10, 80, 230, 100, 0x001a4d, 0x4da6ff);
+        }
         size_t nl = _msg.find('\n');
         if (nl != std::string::npos) {
             centered_text(_msg.substr(0, nl).c_str(), 108, 0x4da6ff, SMALL);

--- a/src/DisplaySettingsScene.cpp
+++ b/src/DisplaySettingsScene.cpp
@@ -3,12 +3,12 @@
 //
 // Turn the encoder to step through all available layouts (rotation × button position).
 
-#ifdef ARDUINO
+#ifdef USE_WIFI
 
 #include "DisplaySettingsScene.h"
 #include "Drawing.h"
 #include "System.h"
-#include "WiFiSetupScene.h"
+#include "SystemScene.h"
 
 static const char* layout_names[] = {
     "0 deg - Btns Bottom",   // rotation 0, buttons below
@@ -32,11 +32,11 @@ void DisplaySettingsScene::onEncoder(int delta) {
 }
 
 void DisplaySettingsScene::onDialButtonPress() {
-    activate_scene(&wifiSetupScene);
+    activate_scene(&systemScene);
 }
 
 void DisplaySettingsScene::onRedButtonPress() {
-    activate_scene(&wifiSetupScene);
+    activate_scene(&systemScene);
 }
 
 void DisplaySettingsScene::reDisplay() {
@@ -62,4 +62,4 @@ void DisplaySettingsScene::reDisplay() {
 
 DisplaySettingsScene displaySettingsScene;
 
-#endif  // ARDUINO
+#endif  // USE_WIFI

--- a/src/Drawing.cpp
+++ b/src/Drawing.cpp
@@ -324,24 +324,25 @@ void drawMenuTitle(const char* name) {
 }
 
 #ifdef USE_WIFI
-// Draw a 4-bar WiFi signal indicator in the top-left corner / arc.
-static void drawWiFiSignalOverlay() {
+// Draw a 4-bar WiFi signal indicator at the given position.
+void drawWiFiSignalBars(int x0, int y_bot) {
     if (!wifi_is_connected()) return;   // No indicator while scanning / AP mode
 
     int bars = wifi_signal_bars();      // 0–4
 
-    // Bar geometry: 4 columns, bottom-aligned, heights grow left → right.
     static constexpr int W   = 3;                   // bar width  (px)
     static constexpr int GAP = 2;                   // gap between bars (px)
     static const     int H[] = { 4, 7, 10, 13 };   // heights: weak → strong
-
-    int x0    = round_display ? 31 : 5;
-    int y_bot = round_display ? 45 : 20;
 
     for (int i = 0; i < 4; i++) {
         int color = (i < bars) ? GREEN : DARKGREY;
         canvas.fillRect(x0 + i * (W + GAP), y_bot - H[i], W, H[i], color);
     }
+}
+
+static void drawWiFiSignalOverlay() {
+    if (round_display) return;   // M5 Dial: WiFi indicator only shown in menu scene
+    drawWiFiSignalBars(5, 20);
 }
 #endif
 

--- a/src/Drawing.h
+++ b/src/Drawing.h
@@ -87,6 +87,10 @@ void drawMenuTitle(const char* name);
 void drawPngFile(const char* filename, Point xy);
 void drawPngBackground(const char* filename);
 
+#ifdef USE_WIFI
+void drawWiFiSignalBars(int x0, int y_bot);
+#endif
+
 void refreshDisplay();
 
 void drawError();

--- a/src/FirstBootScene.cpp
+++ b/src/FirstBootScene.cpp
@@ -78,15 +78,18 @@ public:
         wrapped_text("Connection Mode", 70, 200, ORANGE, SMALL);
 
         // ── Buttons (stacked vertically) ────────────────────────────────────────
-        uartBtn.set(BTN_X, UART_BTN_Y, BTN_W, BTN_H, "Wired",
+        int uart_btn_y = round_display ? UART_BTN_Y - 6 : UART_BTN_Y;
+        int wifi_btn_y = round_display ? WIFI_BTN_Y - 16 : WIFI_BTN_Y;
+        uartBtn.set(BTN_X, uart_btn_y, BTN_W, BTN_H, "Wired",
                     0x001a4d, 0x4da6ff, 0x4da6ff, [this]() { onUartPress(); });
 
-        wifiBtn.set(BTN_X, WIFI_BTN_Y, BTN_W, BTN_H, "WiFi",
+        wifiBtn.set(BTN_X, wifi_btn_y, BTN_W, BTN_H, "WiFi",
                     0x003300, 0x66ff66, 0x66ff66, [this]() { onWifiPress(); });
 
         // ── Footer ─────────────────────────────────────────────────────────────
-        centered_text("This can be changed later", 230, DARKGREY, TINY);
- 
+        if (!round_display) {
+            centered_text("This can be changed later", 230, DARKGREY, TINY);
+        } 
         refreshDisplay();
     }
 

--- a/src/FirstBootScene.cpp
+++ b/src/FirstBootScene.cpp
@@ -4,7 +4,7 @@
 // Asks the user to choose WiFi (WebSocket) or UART (serial cable).
 // Choice is saved to NVS, then transitions directly to the appropriate scene.
 
-#ifdef ARDUINO
+#ifdef USE_WIFI
 
 #    include "Scene.h"
 #    include "Drawing.h"
@@ -98,4 +98,4 @@ public:
 
 FirstBootScene firstBootScene;
 
-#endif  // ARDUINO
+#endif  // USE_WIFI

--- a/src/PieMenu.cpp
+++ b/src/PieMenu.cpp
@@ -70,12 +70,12 @@ int PieMenu::touchedItem(int x, int y) {
 }
 void PieMenu::menuBackground() {
     background();
-    text(selectedItem()->name(), { 0, -15 }, WHITE, SMALL);
-    drawStatusSmall(90);
+    text(selectedItem()->name(), { 0, round_display ? -20 : -15 }, WHITE, SMALL);
+    drawStatusSmall(round_display ? 95 : 90);
 #ifdef USE_WIFI
     if (round_display) {
         // On M5 Dial, show WiFi signal centered just above the status badge (y=90).
-        drawWiFiSignalBars((display_short_side() - 18) / 2, 85);
+        drawWiFiSignalBars((display_short_side() - 18) / 2, 87);
     }
 #endif
 }

--- a/src/PieMenu.cpp
+++ b/src/PieMenu.cpp
@@ -72,6 +72,12 @@ void PieMenu::menuBackground() {
     background();
     text(selectedItem()->name(), { 0, -15 }, WHITE, SMALL);
     drawStatusSmall(90);
+#ifdef USE_WIFI
+    if (round_display) {
+        // On M5 Dial, show WiFi signal centered just above the status badge (y=90).
+        drawWiFiSignalBars((display_short_side() - 18) / 2, 85);
+    }
+#endif
 }
 
 void PieMenu::onTouchFlick() {

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -3,6 +3,9 @@
 
 #include "Scene.h"
 #include "System.h"
+#ifdef USE_WIFI
+#    include "WiFiConnection.h"
+#endif
 
 #ifndef ARDUINO
 #    include <sys/stat.h>
@@ -184,6 +187,9 @@ void dispatch_events() {
     if (!fnc_is_connected()) {
         if (state != Disconnected) {
             set_disconnected_state();
+#ifdef USE_WIFI
+            wifi_force_ws_reconnect();
+#endif
             extern Scene menuScene;
             activate_at_top_level(&menuScene);
         }

--- a/src/StatusScene.cpp
+++ b/src/StatusScene.cpp
@@ -223,6 +223,11 @@ public:
         }
         drawButtonLegends(redLabel, grnLabel, yellowLabel);
 
+#ifdef USE_WIFI
+        if (round_display) {
+            drawWiFiSignalBars(70, 20);
+        }
+#endif
         refreshDisplay();
     }
 };

--- a/src/SystemMacOS.cpp
+++ b/src/SystemMacOS.cpp
@@ -295,9 +295,9 @@ void redrawButtons() {}
 // These let the WiFi scenes compile and render on the SDL simulator.
 // All networking is no-op; status values are fixed to show a connected state.
 
-static WiFiConfig _preview_cfg = { "Preview SSID", "", "192.168.1.100", true };
+static WiFiConfig _preview_cfg = { "Preview SSID", "", "192.168.1.100", false };
 
-void        wifi_init()                    {}
+void        wifi_init(bool)               {}
 void        wifi_poll()                    {}
 bool        wifi_is_connected()            { return true; }
 bool        websocket_is_connected()       { return true; }

--- a/src/SystemMacOS.cpp
+++ b/src/SystemMacOS.cpp
@@ -10,6 +10,9 @@
 #include "M5GFX.h"
 #include "Drawing.h"
 #include "NVS.h"
+#ifdef USE_WIFI
+#    include "WiFiConnection.h"
+#endif
 
 #include <fcntl.h>
 #include <termios.h>
@@ -106,7 +109,9 @@ void base_display() {
     display.clear();
 }
 
-void next_layout(int delta) {}
+int     num_layouts = 1;
+int32_t layout_num  = 0;
+void    next_layout(int delta) {}
 
 void resetFlowControl() {}
 
@@ -284,3 +289,34 @@ bool ui_locked(bool redrawButtonsFlag) {
 }
 
 void redrawButtons() {}
+
+#ifdef USE_WIFI
+// ── WiFi stubs for macOS preview builds ───────────────────────────────────────
+// These let the WiFi scenes compile and render on the SDL simulator.
+// All networking is no-op; status values are fixed to show a connected state.
+
+static WiFiConfig _preview_cfg = { "Preview SSID", "", "192.168.1.100", true };
+
+void        wifi_init()                    {}
+void        wifi_poll()                    {}
+bool        wifi_is_connected()            { return true; }
+bool        websocket_is_connected()       { return true; }
+void        wifi_force_ws_reconnect()      {}
+bool        wifi_in_ap_mode()              { return false; }
+void        wifi_start_ap_setup()          {}
+void        wifi_stop_ap_and_restart()     {}
+void        wifi_stop_ap()                 {}
+void        wifi_save_config(const char*, const char*, const char*) {}
+WiFiConfig  wifi_load_config()             { return _preview_cfg; }
+const char* wifi_ap_ssid()                 { return "FluidDial"; }
+const char* wifi_status_str()              { return "Connected"; }
+const bool  wifi_not_ready()               { return false; }
+int         wifi_signal_bars()             { return 3; }
+const char* wifi_last_error()              { return nullptr; }
+WiFiConfig  wifi_active_config()           { return _preview_cfg; }
+void        ws_putchar(uint8_t)            {}
+int         ws_getchar()                   { return -1; }
+bool        wifi_use_uart_mode()           { return false; }
+void        wifi_set_uart_mode(bool)       {}
+bool        wifi_is_first_boot()           { return false; }
+#endif  // USE_WIFI

--- a/src/SystemScene.cpp
+++ b/src/SystemScene.cpp
@@ -16,10 +16,10 @@ struct SysItem {
 };
 
 static const SysItem items[] = {
-    { "Display",  "Screen orientation" },
-    { "Restart",  "Reboot pendant"     },
+    { "Restart",  ""                   },
+    { "Display",  "Adjust orientation" },
 #ifdef USE_M5
-    { "Sleep",    "Red button to wake" },
+    { "Sleep",    "Press red to wake"  },
 #endif
 };
 static const int N_ITEMS = (int)(sizeof(items) / sizeof(items[0]));
@@ -44,12 +44,12 @@ void SystemScene::onEncoder(int delta) {
 void SystemScene::activateSelected() {
     switch (_selected) {
         case 0:
-            activate_scene(&displaySettingsScene);
-            break;
-        case 1:
 #ifdef ARDUINO
             esp_restart();
 #endif
+            break;
+        case 1:
+            activate_scene(&displaySettingsScene);
             break;
 #ifdef USE_M5
         case 2:
@@ -79,11 +79,15 @@ void SystemScene::reDisplay() {
         bool sel = (i == _selected);
 
         if (sel) {
-            drawOutlinedRect(20, y - 2, 200, ITEM_H - 4, 0x001a4d, 0x4da6ff);
+            drawOutlinedRect(30, y - 2, 180, ITEM_H - 4, 0x001a4d, 0x4da6ff);
         }
 
-        centered_text(items[i].label,    y + 12, sel ? WHITE    : LIGHTGREY, SMALL);
-        centered_text(items[i].sublabel, y + 28, sel ? 0x4da6ff : DARKGREY,  TINY);
+        bool has_sub = items[i].sublabel[0] != '\0';
+        int  label_y = has_sub ? y + 12 : y + ITEM_H / 2;
+        centered_text(items[i].label,    label_y, sel ? WHITE    : LIGHTGREY, SMALL);
+        if (has_sub) {
+            centered_text(items[i].sublabel, y + 32, sel ? 0x4da6ff : DARKGREY, TINY);
+        }
     }
 
     drawButtonLegends("Back", "Select", "");

--- a/src/SystemScene.cpp
+++ b/src/SystemScene.cpp
@@ -1,0 +1,95 @@
+// 2026 - Figamore
+// SystemScene.cpp — "More" settings hub: display orientation, restart, sleep.
+
+#ifdef USE_WIFI
+
+#include "SystemScene.h"
+#include "DisplaySettingsScene.h"
+#include "WiFiSetupScene.h"
+#include "Drawing.h"
+#include "System.h"
+#include "FluidNCModel.h"
+
+struct SysItem {
+    const char* label;
+    const char* sublabel;
+};
+
+static const SysItem items[] = {
+    { "Display",  "Screen orientation" },
+    { "Restart",  "Reboot pendant"     },
+#ifdef USE_M5
+    { "Sleep",    "Red button to wake" },
+#endif
+};
+static const int N_ITEMS = (int)(sizeof(items) / sizeof(items[0]));
+
+static constexpr int ITEM_H   = 48;
+static constexpr int START_Y  = 50;
+
+int SystemScene::itemCount() { return N_ITEMS; }
+
+void SystemScene::onEntry(void* arg) {
+    _selected = 0;
+    reDisplay();
+}
+
+void SystemScene::onEncoder(int delta) {
+    _selected += delta;
+    if (_selected < 0)        _selected = N_ITEMS - 1;
+    if (_selected >= N_ITEMS) _selected = 0;
+    reDisplay();
+}
+
+void SystemScene::activateSelected() {
+    switch (_selected) {
+        case 0:
+            activate_scene(&displaySettingsScene);
+            break;
+        case 1:
+#ifdef ARDUINO
+            esp_restart();
+#endif
+            break;
+#ifdef USE_M5
+        case 2:
+            set_disconnected_state();
+#    ifdef ARDUINO
+            centered_text("Red button to wake", 118, RED, TINY);
+            refreshDisplay();
+            delay_ms(2000);
+            deep_sleep(0);
+#    endif
+            break;
+#endif
+    }
+}
+
+void SystemScene::onDialButtonPress()  { activateSelected(); }
+void SystemScene::onGreenButtonPress() { activateSelected(); }
+void SystemScene::onRedButtonPress()   { activate_scene(&wifiSetupScene); }
+
+void SystemScene::reDisplay() {
+    background();
+    drawMenuTitle("System");
+    drawRect(55, 22, 130, 1, 0, DARKGREY);
+
+    for (int i = 0; i < N_ITEMS; i++) {
+        int  y   = START_Y + i * ITEM_H;
+        bool sel = (i == _selected);
+
+        if (sel) {
+            drawOutlinedRect(20, y - 2, 200, ITEM_H - 4, 0x001a4d, 0x4da6ff);
+        }
+
+        centered_text(items[i].label,    y + 12, sel ? WHITE    : LIGHTGREY, SMALL);
+        centered_text(items[i].sublabel, y + 28, sel ? 0x4da6ff : DARKGREY,  TINY);
+    }
+
+    drawButtonLegends("Back", "Select", "");
+    refreshDisplay();
+}
+
+SystemScene systemScene;
+
+#endif  // USE_WIFI

--- a/src/SystemScene.cpp
+++ b/src/SystemScene.cpp
@@ -24,8 +24,12 @@ static const SysItem items[] = {
 };
 static const int N_ITEMS = (int)(sizeof(items) / sizeof(items[0]));
 
-static constexpr int ITEM_H   = 48;
-static constexpr int START_Y  = 50;
+static constexpr int ITEM_H_ROUND     = 48;
+static constexpr int ITEM_PITCH_ROUND = 48;
+static constexpr int ITEM_H_CYD       = 48;
+static constexpr int ITEM_PITCH_CYD   = 72;
+static constexpr int START_Y_ROUND    = 50;
+static constexpr int START_Y_CYD      = 60;
 
 int SystemScene::itemCount() { return N_ITEMS; }
 
@@ -69,21 +73,40 @@ void SystemScene::onDialButtonPress()  { activateSelected(); }
 void SystemScene::onGreenButtonPress() { activateSelected(); }
 void SystemScene::onRedButtonPress()   { activate_scene(&wifiSetupScene); }
 
+void SystemScene::onTouchClick() {
+    int item_h    = round_display ? ITEM_H_ROUND    : ITEM_H_CYD;
+    int item_pitch = round_display ? ITEM_PITCH_ROUND : ITEM_PITCH_CYD;
+    int start_y   = round_display ? START_Y_ROUND   : START_Y_CYD;
+    for (int i = 0; i < N_ITEMS; i++) {
+        int y = start_y + i * item_pitch;
+        if (touchX >= 30 && touchX <= 210 && touchY >= y - 2 && touchY < y + item_h - 4) {
+            _selected = i;
+            reDisplay();
+            activateSelected();
+            return;
+        }
+    }
+}
+
 void SystemScene::reDisplay() {
+    int item_h     = round_display ? ITEM_H_ROUND    : ITEM_H_CYD;
+    int item_pitch = round_display ? ITEM_PITCH_ROUND : ITEM_PITCH_CYD;
+    int start_y    = round_display ? START_Y_ROUND   : START_Y_CYD;
+
     background();
     drawMenuTitle("System");
     drawRect(55, 22, 130, 1, 0, DARKGREY);
 
     for (int i = 0; i < N_ITEMS; i++) {
-        int  y   = START_Y + i * ITEM_H;
+        int  y   = start_y + i * item_pitch;
         bool sel = (i == _selected);
 
         if (sel) {
-            drawOutlinedRect(30, y - 2, 180, ITEM_H - 4, 0x001a4d, 0x4da6ff);
+            drawOutlinedRect(30, y - 2, 180, item_h - 4, 0x001a4d, 0x4da6ff);
         }
 
         bool has_sub = items[i].sublabel[0] != '\0';
-        int  label_y = has_sub ? y + 12 : y + ITEM_H / 2;
+        int  label_y = has_sub ? y + 12 : y + item_h / 2;
         centered_text(items[i].label,    label_y, sel ? WHITE    : LIGHTGREY, SMALL);
         if (has_sub) {
             centered_text(items[i].sublabel, y + 32, sel ? 0x4da6ff : DARKGREY, TINY);

--- a/src/SystemScene.h
+++ b/src/SystemScene.h
@@ -15,6 +15,7 @@ public:
     void onDialButtonPress() override;
     void onGreenButtonPress() override;
     void onRedButtonPress() override;
+    void onTouchClick() override;
     void reDisplay() override;
 
 private:

--- a/src/SystemScene.h
+++ b/src/SystemScene.h
@@ -4,17 +4,24 @@
 
 #include "Scene.h"
 
-class DisplaySettingsScene : public Scene {
+class SystemScene : public Scene {
+    int _selected = 0;
+
 public:
-    DisplaySettingsScene() : Scene("Display") {}
+    SystemScene() : Scene("System") {}
 
     void onEntry(void* arg = nullptr) override;
     void onEncoder(int delta) override;
     void onDialButtonPress() override;
+    void onGreenButtonPress() override;
     void onRedButtonPress() override;
     void reDisplay() override;
+
+private:
+    void activateSelected();
+    static int itemCount();
 };
 
-extern DisplaySettingsScene displaySettingsScene;
+extern SystemScene systemScene;
 
 #endif  // USE_WIFI

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -120,7 +120,7 @@ static void ws_begin(const char* host) {
     webSocket.begin(host, FLUIDNC_WS_PORT, FLUIDNC_WS_PATH, WS_SUBPROTOCOL);
     webSocket.onEvent(onWsEvent);
     webSocket.setReconnectInterval(3000);
-    webSocket.enableHeartbeat(15000, 3000, 2);
+    webSocket.enableHeartbeat(5000, 2000, 1);
     _ws_started = true;
 }
 
@@ -605,6 +605,16 @@ bool wifi_is_connected() {
 
 bool websocket_is_connected() {
     return _ws_connected;
+}
+
+void wifi_force_ws_reconnect() {
+    if (_ws_started) {
+        webSocket.disconnect();
+        _ws_connected = false;
+        // Leave _ws_started true — WebSocketsClient will auto-reconnect
+        // on the next webSocket.loop() via setReconnectInterval().
+        dbg_println("WS: force-closed for reconnect");
+    }
 }
 
 bool wifi_in_ap_mode() {

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -596,7 +596,9 @@ void wifi_stop_ap() {
     _wifi_stack_started = false;
 
     // Re-initiate the STA connection that was torn down by wifi_start_ap_setup().
-    wifi_init();
+    // Pass auto_ap=false so that a device with no credentials does not immediately
+    // re-enter AP mode — the user explicitly chose to exit.
+    wifi_init(false);
 }
 
 bool wifi_is_connected() {
@@ -664,7 +666,7 @@ static void onWiFiDisconnect(WiFiEvent_t event, WiFiEventInfo_t info) {
     _wifi_disconnect_reason = info.wifi_sta_disconnected.reason;
 }
 
-void wifi_init() {
+void wifi_init(bool auto_ap) {
     if (wifi_use_uart_mode()) {
         dbg_println("Transport: UART mode — WiFi stack not started");
         return;
@@ -677,11 +679,13 @@ void wifi_init() {
     WiFiConfig cfg = wifi_load_config();
 
     if (!cfg.valid) {
-        // No credentials saved yet — auto-start AP so the user can configure
-        // via browser immediately (captive portal at 192.168.4.1).
-        dbg_println("No WiFi credentials — starting AP setup mode automatically");
-        wifi_start_ap_setup();
-        current_scene->reDisplay();  // switch scene from "not configured" to AP view
+        if (auto_ap) {
+            // No credentials saved yet — auto-start AP so the user can configure
+            // via browser immediately (captive portal at 192.168.4.1).
+            dbg_println("No WiFi credentials — starting AP setup mode automatically");
+            wifi_start_ap_setup();
+            current_scene->reDisplay();  // switch scene from "not configured" to AP view
+        }
         return;
     }
 

--- a/src/WiFiConnection.h
+++ b/src/WiFiConnection.h
@@ -14,8 +14,8 @@ struct WiFiConfig {
     bool valid;
 };
 
-// Initialise WiFi. If no credentials saved, starts AP setup mode.
-void wifi_init();
+// Initialise WiFi. If no credentials saved and auto_ap is true, starts AP setup mode.
+void wifi_init(bool auto_ap = true);
 
 // Must be called from main loop() — processes WebSocket events,
 // DNS and HTTP requests in AP mode, ping timers, etc.

--- a/src/WiFiConnection.h
+++ b/src/WiFiConnection.h
@@ -23,6 +23,10 @@ void wifi_poll();
 
 bool wifi_is_connected();       // ESP32 STA joined the network
 bool websocket_is_connected();  // WebSocket connection to FluidNC is up
+
+// Force-close the WebSocket so it can reconnect cleanly.
+// Called when fnc_is_connected() declares FluidNC unresponsive.
+void wifi_force_ws_reconnect();
 bool wifi_in_ap_mode();         // Running as access point for initial setup
 
 // Start a captive-portal AP named "FluidDial".

--- a/src/WiFiConnection.h
+++ b/src/WiFiConnection.h
@@ -3,7 +3,7 @@
 // WiFi/WebSocket connection layer for FluidDial
 // Replaces UART (fnc_putchar/fnc_getchar) with WebSocket transport
 
-#ifdef ARDUINO
+#ifdef USE_WIFI
 
 #include <stdint.h>
 
@@ -70,4 +70,4 @@ void wifi_set_uart_mode(bool uart); // write to NVS and update cache
 
 bool wifi_is_first_boot();
 
-#endif  // ARDUINO
+#endif  // USE_WIFI

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -112,8 +112,8 @@ void WiFiSetupScene::drawApView() {
     int bx = round_display ? 55 : BX;
     int bw = round_display ? 130 : BW;
     int bh = round_display ? 24 : BH;
-    drawOutlinedRect(bx - 5, BY - 3, bw + 10, bh + 6, 0x8400, 0x8400);  // dark orange
-    centered_text("AP Setup Mode", BY + bh / 2 + 3, WHITE, SMALL);
+    drawOutlinedRect(bx - 5, BY + 5, bw + 10, bh + 6, 0x8400, 0x8400);  // dark orange
+    centered_text("AP Mode", BY + bh / 2 + 10, WHITE, SMALL);
 
     // ── AP Info ────────────────────────────────────────────────────────────────
     int y = CARD_Y0 + 14;
@@ -128,7 +128,7 @@ void WiFiSetupScene::drawApView() {
     drawRect(40, y - 2, 160, 1, 0, DARKGREY);  // divider
 
     // IP section
-    y += line_height + 8;
+    y += line_height + 4;
     centered_text("Open Browser To:", y, LIGHTGREY, TINY);
     y += line_height;
     centered_text("192.168.4.1", y, GREEN, SMALL);

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -20,7 +20,7 @@ extern const char* git_info;
 
 static constexpr int BX = 20, BY = 28, BW = 200, BH = 34;       // status badge
 static constexpr int CX = 15, CW = 210, CH = 28, CI = 8;        // info cards
-static constexpr int SBX = 20, SBY = 166, SBW = 200, SBH = 36;  // switch button
+static constexpr int SBX = 20, SBY = 160, SBW = 200, SBH = 36;  // switch button
 
 static constexpr int CARD_Y0    = 68;
 static constexpr int CARD_PITCH = CH + 4;  // 32 px per card row
@@ -189,8 +189,8 @@ void WiFiSetupScene::drawSettingsView() {
     int bx = round_display ? 55 : BX;
     int bw = round_display ? 130 : BW;
     int bh = round_display ? 24 : BH;
-    drawOutlinedRect(bx - 5, BY - 3, bw + 10, bh + 6, badge_fill, badge_outline);
-    centered_text(badge_label, BY + bh / 2 + 3, badge_text, SMALL);
+    drawOutlinedRect(bx - 5, BY + 6, bw + 10, bh + 6, badge_fill, badge_outline);
+    centered_text(badge_label, BY + bh / 2 + 9, badge_text, SMALL);
 
     // ── Info section ──────────────────────────────────────────────────────────
     int y = CARD_Y0;
@@ -207,11 +207,11 @@ void WiFiSetupScene::drawSettingsView() {
         centered_text("to setup WiFi", y, 0xe02b2b, TINY);
     } else {
         // Network label + SSID — always visible so the user knows what we're connecting to
-        y +=10;
+        y +=8;
         centered_text("Network", y, DARKGREY, TINY);
         y += 20;
         centered_text(cfg.ssid, y, WHITE, SMALL);
-        y += 20;
+        y += 14;
 
         drawRect(40, y, 160, 1, 0, DARKGREY);  // divider
         y += 14;

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -3,7 +3,7 @@
 //
 // Shows connection status and offers AP-mode setup.
 
-#ifdef ARDUINO
+#ifdef USE_WIFI
 
 #include "WiFiSetupScene.h"
 #include "WiFiConnection.h"
@@ -11,7 +11,7 @@
 #include "Menu.h"
 #include "System.h"
 #include "Button.h"
-#include "DisplaySettingsScene.h"
+#include "SystemScene.h"
 
 extern Scene       menuScene;
 extern const char* git_info;
@@ -61,7 +61,9 @@ void WiFiSetupScene::onStateChange(state_t){ reDisplay(); }
 
 void WiFiSetupScene::switchModeAndRestart() {
     wifi_set_uart_mode(!wifi_use_uart_mode());
+#ifdef ARDUINO
     ESP.restart();
+#endif
 }
 
 void WiFiSetupScene::onModeSwitchButtonPress() {
@@ -87,13 +89,15 @@ void WiFiSetupScene::onGreenButtonPress() {
         wifi_start_ap_setup();
         reDisplay();
     } else {
+#ifdef ARDUINO
         ESP.restart();
+#endif
     }
 }
 
 void WiFiSetupScene::onDialButtonPress() {
     if (!wifi_in_ap_mode()) {
-        activate_scene(&displaySettingsScene);
+        activate_scene(&systemScene);
     }
 }
 
@@ -235,7 +239,7 @@ void WiFiSetupScene::drawSettingsView() {
     // ── Button legends ────────────────────────────────────────────────────────
     const char* red_label   = "Back";
     const char* green_label = uart_mode ? "Restart" : "Setup";
-    drawButtonLegends(red_label, green_label, "Display");
+    drawButtonLegends(red_label, green_label, "More");
 }
 
 void WiFiSetupScene::reDisplay() {
@@ -266,4 +270,4 @@ void WiFiSetupScene::reDisplay() {
 
 WiFiSetupScene wifiSetupScene;
 
-#endif  // ARDUINO
+#endif  // USE_WIFI

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -194,7 +194,7 @@ void WiFiSetupScene::drawSettingsView() {
     int bh = round_display ? 24 : BH;
     int ty = round_display ? BY + bh / 2 + 9 : BY + bh / 2 + 3;
     drawOutlinedRect(bx - 5, by, bw + 10, bh + 6, badge_fill, badge_outline);
-    centered_text(badge_label, ty, badge_text, SMALL);
+    centered_text(badge_label, ty, badge_text, round_display ? TINY : SMALL);
 
     // ── Info section ──────────────────────────────────────────────────────────
     int y = CARD_Y0;

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -109,8 +109,11 @@ void WiFiSetupScene::onTouchClick() {
 
 void WiFiSetupScene::drawApView() {
     // ── Status badge ──────────────────────────────────────────────────────────
-    drawOutlinedRect(BX - 5, BY - 3, BW + 10, BH + 6, 0x8400, 0x8400);  // dark orange
-    centered_text("AP Setup Mode", BY + BH / 2 + 3, WHITE, SMALL);
+    int bx = round_display ? 55 : BX;
+    int bw = round_display ? 130 : BW;
+    int bh = round_display ? 24 : BH;
+    drawOutlinedRect(bx - 5, BY - 3, bw + 10, bh + 6, 0x8400, 0x8400);  // dark orange
+    centered_text("AP Setup Mode", BY + bh / 2 + 3, WHITE, SMALL);
 
     // ── AP Info ────────────────────────────────────────────────────────────────
     int y = CARD_Y0 + 14;
@@ -159,7 +162,7 @@ void WiFiSetupScene::drawSettingsView() {
     } else if (ws_ok) {
         badge_fill    = 0x003300;
         badge_outline = 0x66ff66;
-        badge_label   = "Connected";
+        badge_label   = "Ready";
         badge_text    = 0x66ff66;
     } else if (wf_ok) {
         // WiFi up — waiting for FluidNC WebSocket
@@ -183,8 +186,11 @@ void WiFiSetupScene::drawSettingsView() {
         badge_text    = WHITE;
     }
 
-    drawOutlinedRect(BX - 5, BY - 3, BW + 10, BH + 6, badge_fill, badge_outline);
-    centered_text(badge_label, BY + BH / 2 + 3, badge_text, SMALL);
+    int bx = round_display ? 55 : BX;
+    int bw = round_display ? 130 : BW;
+    int bh = round_display ? 24 : BH;
+    drawOutlinedRect(bx - 5, BY - 3, bw + 10, bh + 6, badge_fill, badge_outline);
+    centered_text(badge_label, BY + bh / 2 + 3, badge_text, SMALL);
 
     // ── Info section ──────────────────────────────────────────────────────────
     int y = CARD_Y0;
@@ -233,7 +239,10 @@ void WiFiSetupScene::drawSettingsView() {
         int         sw_fill       = uart_mode ? 0x003300: 0x001a4d;
         int         sw_outline    = uart_mode ? 0x66ff66: 0x4da6ff;
 
-        modeSwitchBtn.set(SBX, SBY, SBW, SBH, sw_label, sw_fill, sw_outline, sw_outline, [this]() { onModeSwitchButtonPress(); });
+        int sbx = round_display ? 40 : SBX;
+        int sbw = round_display ? 160 : SBW;
+        modeSwitchBtn.font = round_display ? TINY : SMALL;
+        modeSwitchBtn.set(sbx, SBY, sbw, SBH, sw_label, sw_fill, sw_outline, sw_outline, [this]() { onModeSwitchButtonPress(); });
     }
 
     // ── Button legends ────────────────────────────────────────────────────────
@@ -246,17 +255,35 @@ void WiFiSetupScene::reDisplay() {
     background();
 
     const char* title;
-    if (wifi_in_ap_mode() || wifi_use_uart_mode() || !wifi_active_config().valid) {
-        title = "Connection Settings";
-    } else if (websocket_is_connected()) {
-        title = " Connected to FluidNC";
-    } else if (wifi_is_connected()) {
-        title = " Connecting to FluidNC";
+    if (round_display) {
+        // Shorter titles for M5 Dial: top of circle is narrow (~104px at y=12)
+        if (wifi_in_ap_mode() || wifi_use_uart_mode() || !wifi_active_config().valid) {
+            title = "WiFi Setup";
+        } else if (websocket_is_connected()) {
+            title = "Connected";
+        } else if (wifi_is_connected()) {
+            title = "Connecting";
+        } else {
+            title = "WiFi Setup";
+        }
     } else {
-        title = "Connecting to WiFi";
+        if (wifi_in_ap_mode() || wifi_use_uart_mode() || !wifi_active_config().valid) {
+            title = "Connection Settings";
+        } else if (websocket_is_connected()) {
+            title = " Connected to FluidNC";
+        } else if (wifi_is_connected()) {
+            title = " Connecting to FluidNC";
+        } else {
+            title = "Connecting to WiFi";
+        }
     }
-    centered_text(title, 12);
-    drawRect(55, 22, 130, 1, 0, DARKGREY);
+    if (round_display) {
+        centered_text(title, 18);
+        drawRect(70, 28, 100, 1, 0, DARKGREY);
+    } else {
+        centered_text(title, 12);
+        drawRect(55, 22, 130, 1, 0, DARKGREY);
+    }
 
     if (wifi_in_ap_mode()) {
         drawApView();

--- a/src/WiFiSetupScene.cpp
+++ b/src/WiFiSetupScene.cpp
@@ -109,11 +109,13 @@ void WiFiSetupScene::onTouchClick() {
 
 void WiFiSetupScene::drawApView() {
     // ── Status badge ──────────────────────────────────────────────────────────
+    int by = round_display ? BY + 5 : BY - 3;
     int bx = round_display ? 55 : BX;
     int bw = round_display ? 130 : BW;
     int bh = round_display ? 24 : BH;
-    drawOutlinedRect(bx - 5, BY + 5, bw + 10, bh + 6, 0x8400, 0x8400);  // dark orange
-    centered_text("AP Mode", BY + bh / 2 + 10, WHITE, SMALL);
+    int ty = round_display ? BY + bh / 2 + 10 : BY + bh / 2 + 3;
+    drawOutlinedRect(bx - 5, by, bw + 10, bh + 6, 0x8400, 0x8400);  // dark orange
+    centered_text("AP Mode", ty, WHITE, SMALL);
 
     // ── AP Info ────────────────────────────────────────────────────────────────
     int y = CARD_Y0 + 14;
@@ -187,10 +189,12 @@ void WiFiSetupScene::drawSettingsView() {
     }
 
     int bx = round_display ? 55 : BX;
+    int by = round_display ? BY + 6 : BY - 3;
     int bw = round_display ? 130 : BW;
     int bh = round_display ? 24 : BH;
-    drawOutlinedRect(bx - 5, BY + 6, bw + 10, bh + 6, badge_fill, badge_outline);
-    centered_text(badge_label, BY + bh / 2 + 9, badge_text, SMALL);
+    int ty = round_display ? BY + bh / 2 + 9 : BY + bh / 2 + 3;
+    drawOutlinedRect(bx - 5, by, bw + 10, bh + 6, badge_fill, badge_outline);
+    centered_text(badge_label, ty, badge_text, SMALL);
 
     // ── Info section ──────────────────────────────────────────────────────────
     int y = CARD_Y0;
@@ -207,11 +211,11 @@ void WiFiSetupScene::drawSettingsView() {
         centered_text("to setup WiFi", y, 0xe02b2b, TINY);
     } else {
         // Network label + SSID — always visible so the user knows what we're connecting to
-        y +=8;
+        y += (round_display ? 8 : 10);
         centered_text("Network", y, DARKGREY, TINY);
         y += 20;
         centered_text(cfg.ssid, y, WHITE, SMALL);
-        y += 14;
+        y += (round_display ? 14 : 20);
 
         drawRect(40, y, 160, 1, 0, DARKGREY);  // divider
         y += 14;
@@ -241,8 +245,9 @@ void WiFiSetupScene::drawSettingsView() {
 
         int sbx = round_display ? 40 : SBX;
         int sbw = round_display ? 160 : SBW;
+        int sby = round_display ? SBY : SBY + 6;
         modeSwitchBtn.font = round_display ? TINY : SMALL;
-        modeSwitchBtn.set(sbx, SBY, sbw, SBH, sw_label, sw_fill, sw_outline, sw_outline, [this]() { onModeSwitchButtonPress(); });
+        modeSwitchBtn.set(sbx, sby, sbw, SBH, sw_label, sw_fill, sw_outline, sw_outline, [this]() { onModeSwitchButtonPress(); });
     }
 
     // ── Button legends ────────────────────────────────────────────────────────

--- a/src/WiFiSetupScene.h
+++ b/src/WiFiSetupScene.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef ARDUINO
+#ifdef USE_WIFI
 
 #include "Scene.h"
 #include "Button.h"
@@ -27,4 +27,4 @@ private:
 
 extern WiFiSetupScene wifiSetupScene;
 
-#endif  // ARDUINO
+#endif  // USE_WIFI


### PR DESCRIPTION
This PR fixes several layout issues for the M5 dial variant that were introduced when WiFi setup scenes were introduced in the previous PR. The reset and sleep functions have been added back in a "More settings" menu and web socket disconnects are now gracefully handled.