### PR TITLE
Make WiFi actually usable: TCP/lwip transport + RX flow control + several other fixes

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,6 @@ lib_deps =
     ${common.lib_deps}
     m5stack/M5Unified
     m5stack/M5Dial
-    links2004/WebSockets @ ^2.4.0
 build_flags =
     ${common.build_flags}
     -DUSE_M5
@@ -65,7 +64,6 @@ lib_deps =
     ${common.lib_deps}
     ; m5stack/M5Unified
     LovyanGFX=https://github.com/lovyan03/LovyanGFX#develop
-    links2004/WebSockets @ ^2.4.0
 build_flags =
     ${common.build_flags}
     -DUSE_LOVYANGFX

--- a/src/AboutScene.cpp
+++ b/src/AboutScene.cpp
@@ -4,6 +4,7 @@
 #include "Scene.h"
 #include "FileParser.h"
 #include "AboutScene.h"
+#include "BootLog.h"
 
 extern Scene menuScene;
 
@@ -107,6 +108,25 @@ void AboutScene::reDisplay() {
                 wifi_str = "IP ";
                 wifi_str += wifi_ip;
                 centered_text(wifi_str.c_str(), y += y_spacing, LIGHTGREY, TINY);
+            }
+        }
+    }
+
+    // When the link is down, surface the last few boot/handshake log lines
+    // here. UART0 is shared with the USB-serial bridge on CYD, so this is
+    // the only way to see what is happening without unplugging.
+    if (state == Disconnected) {
+        const int log_line_spacing = 10;
+        int       log_y            = y + 14;
+        centered_text("Boot log (newest first):", log_y, YELLOW, TINY);
+        const int max_lines = 6;
+        int       avail     = bootlog_count();
+        int       shown     = avail < max_lines ? avail : max_lines;
+        for (int i = 0; i < shown; i++) {
+            const char* line = bootlog_line(i);
+            if (line) {
+                log_y += log_line_spacing;
+                centered_text(line, log_y, LIGHTGREY, TINY);
             }
         }
     }

--- a/src/BootLog.cpp
+++ b/src/BootLog.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 - Paul Mokbel
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+#include "BootLog.h"
+#include "GrblParserC.h"  // milliseconds()
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+static char s_lines[BOOTLOG_NUM_LINES][BOOTLOG_LINE_LEN];
+static int  s_head  = 0;  // index of next slot to write
+static int  s_count = 0;  // number of valid entries (capped)
+
+extern "C" void bootlog_printf(const char* fmt, ...) {
+    char* slot = s_lines[s_head];
+    int   ms   = milliseconds();
+    int   n    = snprintf(slot, BOOTLOG_LINE_LEN, "[%6d] ", ms);
+    if (n < 0 || n >= BOOTLOG_LINE_LEN) {
+        slot[BOOTLOG_LINE_LEN - 1] = '\0';
+    } else {
+        va_list args;
+        va_start(args, fmt);
+        vsnprintf(slot + n, BOOTLOG_LINE_LEN - n, fmt, args);
+        va_end(args);
+    }
+    slot[BOOTLOG_LINE_LEN - 1] = '\0';
+    s_head = (s_head + 1) % BOOTLOG_NUM_LINES;
+    if (s_count < BOOTLOG_NUM_LINES) {
+        s_count++;
+    }
+}
+
+extern "C" const char* bootlog_line(int i) {
+    if (i < 0 || i >= s_count) {
+        return NULL;
+    }
+    // i==0 is the newest; head points to the next-write slot, so newest is at head-1
+    int idx = (s_head - 1 - i + BOOTLOG_NUM_LINES * 2) % BOOTLOG_NUM_LINES;
+    return s_lines[idx];
+}
+
+extern "C" int bootlog_count(void) {
+    return s_count;
+}

--- a/src/BootLog.h
+++ b/src/BootLog.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 - Paul Mokbel
+// Use of this source code is governed by a GPLv3 license that can be found in the LICENSE file.
+
+// Tiny RAM ring buffer of recent boot/connection diagnostic lines.
+// Survives until reset (no flash persistence). Viewable on the About
+// scene when the link is down, since UART0 is shared with the
+// USB-serial bridge on CYD and cannot be observed concurrently.
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+#define BOOTLOG_LINE_LEN 64
+#define BOOTLOG_NUM_LINES 48
+
+void bootlog_printf(const char* fmt, ...);
+
+// Returns the i-th most recent line (0 == newest), or NULL if out of range.
+const char* bootlog_line(int i);
+
+// Number of lines currently stored (capped at BOOTLOG_NUM_LINES).
+int bootlog_count(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/Config.h
+++ b/src/Config.h
@@ -16,3 +16,9 @@
 
 // Automatically leave Homing Scene after homing is finished
 // #define AUTO_HOMING_RETURN
+
+// Trace incoming bytes from FluidNC (ok / error:N / [rx-other] / JSON
+// chunk sizes + brace depth + macro-chain advance points) via dbg_printf.
+// Useful when diagnosing wire-protocol issues over Telnet vs UART.
+// Uncomment to enable; zero runtime cost when commented out.
+// #define FNC_RX_TRACE

--- a/src/ConfigItem.cpp
+++ b/src/ConfigItem.cpp
@@ -13,7 +13,7 @@ void parse_dollar(const char* line) {
             line += cmdlen + 1;
             item->got(line);
 
-            current_scene->reDisplay();
+            request_redisplay();
             configRequests.erase(it);
             break;
         }

--- a/src/Drawing.cpp
+++ b/src/Drawing.cpp
@@ -133,7 +133,7 @@ void drawStatus() {
             line1   = "AP Setup";
             line2   = "192.168.4.1";
         } else if (wifi_is_connected()) {
-            bgColor = YELLOW;       // WiFi up, WebSocket still connecting
+            bgColor = YELLOW;       // WiFi up, Telnet still connecting
             line1   = "FluidNC";
             static const char* nc_frames[] = { "Connecting", "Connecting.", "Connecting..", "Connecting..." };
             line2   = nc_frames[(millis() / 400) % 4];
@@ -188,7 +188,7 @@ void drawStatusSmall(int y) {
             bgColor = 0x8400;   // dark orange
             label   = "AP Mode";
         } else if (wifi_is_connected()) {
-            bgColor = YELLOW;   // WiFi up, WebSocket still connecting
+            bgColor = YELLOW;   // WiFi up, Telnet still connecting
             static const char* nc_frames[] = { "FluidNC", "FluidNC.", "FluidNC..", "FluidNC..." };
             label   = nc_frames[(millis() / 400) % 4];
         } else {

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -561,59 +561,6 @@ void request_file_list(const char* dirname) {
     parser_needs_reset = true;
 }
 
-// ── Plain-JSON receiver ───────────────────────────────────────────────────────
-// Large payloads can arrive split across TCP segments (the RX refill is line-
-// terminated by the Telnet path) so GrblParserC delivers them as separate
-// lines to handle_other(). Accumulate fragments until the outermost JSON
-// object is complete (brace depth -> 0), then dispatch to handle_json().
-
-static std::string _json_accum;
-
-static bool json_accum_complete() {
-    int  depth  = 0;
-    bool in_str = false;
-    bool esc    = false;
-    for (char c : _json_accum) {
-        if (esc)       { esc = false; continue; }
-        if (c == '\\') { esc = true;  continue; }
-        if (c == '"')  { in_str = !in_str; continue; }
-        if (!in_str) {
-            if      (c == '{') ++depth;
-            else if (c == '}') { if (--depth == 0) return true; }
-        }
-    }
-    return false;
-}
-
-static bool is_non_json_protocol_message(const char* line) {
-    return line[0] == '<'
-           || strncmp(line, "ok",     2) == 0
-           || strncmp(line, "error:", 6) == 0
-           || strcmp(line, "PING") == 0;
-}
-
-// Returns true if the line was consumed as JSON
-bool receive_plain_json(const char* line) {
-    // Discard non-JSON messages that interrupt an in-progress accumulation
-    if (!_json_accum.empty() && is_non_json_protocol_message(line)) {
-        _json_accum.clear();
-        return false;
-    }
-
-    // Accept the line if it starts a JSON object or continues one.
-    if (line[0] != '{' && _json_accum.empty()) {
-        return false;
-    }
-
-    _json_accum += line;
-
-    if (json_accum_complete()) {
-        handle_json(_json_accum.c_str());
-        _json_accum.clear();
-    }
-    return true;
-}
-
 void init_file_list() {
     init_listener();
     request_file_list("/sd");
@@ -626,20 +573,70 @@ void request_file_preview(const char* name, int firstline, int nlines) {
     // parser.reset();
 }
 
-void parser_parse_line(const char* line) {
+// ── Streaming JSON receiver ───────────────────────────────────────────────────
+// Large payloads can arrive split across TCP segments (the Telnet RX refill is
+// line-terminated) so GrblParserC delivers them as separate lines to
+// handle_other(). Rather than accumulating the whole document into a std::string
+// (which fragments the heap for big file lists), feed each chunk into the
+// streaming JSON parser as it arrives and track outer-brace depth so we know
+// when a document is complete and when the parser is safe to reset.
+
+static int  s_json_depth  = 0;
+static bool s_json_in_str = false;
+static bool s_json_esc    = false;
+
+bool json_in_progress() {
+    return s_json_depth > 0;
+}
+
+void json_reset_depth() {
+    s_json_depth       = 0;
+    s_json_in_str      = false;
+    s_json_esc         = false;
+    parser_needs_reset = true;
+}
+
+// Feed a chunk into the parser one char at a time, counting outer-brace
+// depth as we go. Tracks string state (incl. backslash escapes) across
+// chunk boundaries so '{' and '}' inside JSON string values — for
+// example a macro action like "G92 Z{z}" — don't inflate the counter
+// and prevent the document from ever returning to depth 0.
+static void parser_feed_line(const char* line) {
     char c;
     while ((c = *line++) != '\0') {
+        if (s_json_esc) {
+            s_json_esc = false;
+        } else if (s_json_in_str) {
+            if (c == '\\') {
+                s_json_esc = true;
+            } else if (c == '"') {
+                s_json_in_str = false;
+            }
+        } else {
+            if (c == '"') {
+                s_json_in_str = true;
+            } else if (c == '{') {
+                s_json_depth++;
+            } else if (c == '}') {
+                if (s_json_depth > 0) {
+                    s_json_depth--;
+                }
+            }
+        }
         parser.parse(c);
     }
 }
 
 extern "C" void handle_json(const char* line) {
-    if (parser_needs_reset) {
+    // Only reset the parser at a document boundary, never mid-stream — a reset
+    // in the middle of a multi-chunk document loses the in-flight state and
+    // the macro list comes back empty.
+    if (parser_needs_reset && s_json_depth == 0) {
         parser_needs_reset = false;
         parser.setListener(pInitialListener);
         parser.reset();
     }
-    parser_parse_line(line);
+    parser_feed_line(line);
 }
 
 std::string wifi_mode;

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -639,9 +639,6 @@ extern "C" void handle_json(const char* line) {
         parser.reset();
     }
     parser_parse_line(line);
-
-#define Ack 0xB2
-    fnc_realtime((realtime_cmd_t)Ack);
 }
 
 std::string wifi_mode;

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -328,15 +328,36 @@ void request_json_file(const char* name) {
     parser_needs_reset = true;
 }
 
+// Track which file request is in flight so we can advance the macro
+// chain if FluidNC rejects it with a bare "error:N" (Telnet's terse
+// error form, no JSON wrapper). Without this, a rejection on
+// $File/SendJSON=macrocfg.json never unblocks the chain and the macro
+// menu sits forever on "Reading Macros". Cleared either via the success
+// path (try_next_macro_file from JSON endDocument) or via the failure
+// path (file_request_failed_advance from show_error).
+static JsonListener* s_pending_file_listener = nullptr;
+
+// Cooldown millisecond stamp from the last chain advance. FluidNC over
+// Telnet can emit a bare "error:N" for a failed file request AFTER it
+// has already wrapped that failure in a JSON-status response — by then
+// the chain has advanced to the next file and the stray error byte
+// would falsely advance again. Within this window the second advance
+// is suppressed.
+static uint32_t s_chain_advance_at_ms = 0;
+static constexpr uint32_t CHAIN_ADVANCE_COOLDOWN_MS = 250;
+
 void request_macro_list_wu2() {
-    //    reading_macros = true;
+    s_pending_file_listener = &macrocfgListener;
     request_json_file("macrocfg.json");
 }
 void request_macro_list_wu3() {
+    s_pending_file_listener = &preferencesListener;
     request_json_file("preferences.json");
 }
 
 void try_next_macro_file(JsonListener* listener) {
+    s_pending_file_listener = nullptr;
+    s_chain_advance_at_ms   = milliseconds();
     // We use schedule_action to avoid reentering
     // the parser code.
     if (!listener) {
@@ -351,6 +372,42 @@ void try_next_macro_file(JsonListener* listener) {
         schedule_action(request_macro_list_wu3);
     }
 }
+
+// Called from show_error in FluidNCModel.cpp. If a macrocfg.json or
+// preferences.json request is in flight when FluidNC returns a bare
+// error:N (no JSON wrapper), advance the chain as if endDocument had
+// fired with non-ok status. Without this the macro chain hangs forever
+// on the "Reading Macros" screen when Telnet rejects $File/SendJSON.
+//
+// Suppress when json_in_progress(): FluidNC interleaves messages on the
+// wire, so an error:N from a previously-failed request can arrive AFTER
+// the next request's JSON has started streaming. Advancing in that case
+// kills a healthy in-flight document and shows "No Macros" even though
+// the macros are right there in the buffer.
+extern "C" void file_request_failed_advance() {
+    if (json_in_progress()) {
+#ifdef FNC_RX_TRACE
+        dbg_println("[macro-chain] stale error suppressed (JSON in flight)");
+#endif
+        return;
+    }
+    // Suppress stray error bytes that arrive immediately after a
+    // chain advance — they belong to the request we just transitioned
+    // away from, not the one that's now pending.
+    if (s_chain_advance_at_ms != 0 &&
+        (milliseconds() - s_chain_advance_at_ms) < CHAIN_ADVANCE_COOLDOWN_MS) {
+#ifdef FNC_RX_TRACE
+        dbg_println("[macro-chain] stale error suppressed (advance cooldown)");
+#endif
+        return;
+    }
+    JsonListener* l = s_pending_file_listener;
+    if (l) {
+        s_pending_file_listener = nullptr;
+        try_next_macro_file(l);
+    }
+}
+
 void request_macros() {
     try_next_macro_file(nullptr);
 }

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -562,9 +562,10 @@ void request_file_list(const char* dirname) {
 }
 
 // ── Plain-JSON receiver ───────────────────────────────────────────────────────
-// Large payloads arrive split across several WebSocket frames; the WS receiver appends '\n' to each, so
-// GrblParserC delivers them as separate lines to handle_other().
-// Accumulate fragments until the outermost JSON object is complete (brace depth -> 0), then dispatch to handle_json().
+// Large payloads can arrive split across TCP segments (the RX refill is line-
+// terminated by the Telnet path) so GrblParserC delivers them as separate
+// lines to handle_other(). Accumulate fragments until the outermost JSON
+// object is complete (brace depth -> 0), then dispatch to handle_json().
 
 static std::string _json_accum;
 

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -263,6 +263,12 @@ public:
     void startObject() override { ++_level; }
     void key(const char* key) override {
         _key = key;
+#ifdef FNC_RX_TRACE
+        // Surface every key the preferences listener actually sees, with its
+        // depth-from-listener-perspective, so we can verify the structure
+        // matches what _level == 2 expects.
+        dbg_printf("[prefs] L%d key=%s\n", _level, key);
+#endif
         if (_level < 2) {
             // The only thing we care about is the macros section at level 2
             return;
@@ -347,10 +353,16 @@ static uint32_t s_chain_advance_at_ms = 0;
 static constexpr uint32_t CHAIN_ADVANCE_COOLDOWN_MS = 250;
 
 void request_macro_list_wu2() {
+#ifdef FNC_RX_TRACE
+    dbg_printf("[macro-chain] request macrocfg.json (wu2)\n");
+#endif
     s_pending_file_listener = &macrocfgListener;
     request_json_file("macrocfg.json");
 }
 void request_macro_list_wu3() {
+#ifdef FNC_RX_TRACE
+    dbg_printf("[macro-chain] request preferences.json (wu3)\n");
+#endif
     s_pending_file_listener = &preferencesListener;
     request_json_file("preferences.json");
 }
@@ -361,14 +373,23 @@ void try_next_macro_file(JsonListener* listener) {
     // We use schedule_action to avoid reentering
     // the parser code.
     if (!listener) {
+#ifdef FNC_RX_TRACE
+        dbg_printf("[macro-chain] start -> wu2\n");
+#endif
         schedule_action(request_macro_list_wu2);
         return;
     }
     if (listener == &preferencesListener) {
+#ifdef FNC_RX_TRACE
+        dbg_printf("[macro-chain] preferences exhausted -> No Macros\n");
+#endif
         current_scene->onError("No Macros");
         return;
     }
     if (listener == &macrocfgListener) {
+#ifdef FNC_RX_TRACE
+        dbg_printf("[macro-chain] macrocfg miss -> wu3\n");
+#endif
         schedule_action(request_macro_list_wu3);
     }
 }
@@ -387,7 +408,7 @@ void try_next_macro_file(JsonListener* listener) {
 extern "C" void file_request_failed_advance() {
     if (json_in_progress()) {
 #ifdef FNC_RX_TRACE
-        dbg_println("[macro-chain] stale error suppressed (JSON in flight)");
+        dbg_printf("[macro-chain] stale error suppressed (JSON in flight)\n");
 #endif
         return;
     }
@@ -397,12 +418,17 @@ extern "C" void file_request_failed_advance() {
     if (s_chain_advance_at_ms != 0 &&
         (milliseconds() - s_chain_advance_at_ms) < CHAIN_ADVANCE_COOLDOWN_MS) {
 #ifdef FNC_RX_TRACE
-        dbg_println("[macro-chain] stale error suppressed (advance cooldown)");
+        dbg_printf("[macro-chain] stale error suppressed (advance cooldown)\n");
 #endif
         return;
     }
     JsonListener* l = s_pending_file_listener;
     if (l) {
+#ifdef FNC_RX_TRACE
+        dbg_printf("[macro-chain] file request failed, advancing from %s\n",
+                   l == &macrocfgListener ? "macrocfg" :
+                   l == &preferencesListener ? "preferences" : "?");
+#endif
         s_pending_file_listener = nullptr;
         try_next_macro_file(l);
     }
@@ -685,6 +711,18 @@ static void parser_feed_line(const char* line) {
 }
 
 extern "C" void handle_json(const char* line) {
+#ifdef FNC_RX_TRACE
+    // Print depth + the leading 60 chars of the chunk so we can SEE the
+    // wire format. Truncated to avoid drowning the monitor on large
+    // documents.
+    size_t len = strlen(line);
+    char   peek[61];
+    size_t pn = len < 60 ? len : 60;
+    memcpy(peek, line, pn);
+    peek[pn] = '\0';
+    dbg_printf("[json] len=%u d=%d | %s%s\n", (unsigned)len, s_json_depth,
+               peek, len > 60 ? "..." : "");
+#endif
     // Only reset the parser at a document boundary, never mid-stream — a reset
     // in the middle of a multi-chunk document loses the in-flight state and
     // the macro list comes back empty.

--- a/src/FileParser.cpp
+++ b/src/FileParser.cpp
@@ -3,7 +3,7 @@
 
 #include "FileParser.h"
 
-#include "Scene.h"  // current_scene->reDisplay()
+#include "Scene.h"  // request_redisplay()
 #include "Menu.h"
 #include "GrblParserC.h"  // send_line()
 #include "HomingScene.h"  // set_axis_homed()
@@ -670,14 +670,39 @@ void parse_wifi(char* arguments) {
 }
 
 // command is "Mode=STA" - or AP or No Wifi
+//
+// FluidNC re-emits [MSG:Mode=...] periodically as a heartbeat. Forcing a
+// full reDisplay every time hammers the heap (every PNG decode allocates
+// & frees, and the LGFX/pngle allocator fragments over time -> mDNS OOMs
+// after a minute). We now only reDisplay when something the UI shows has
+// actually changed.
 void handle_radio_mode(char* command, char* arguments) {
-    dbg_printf("Mode %s %s\n", command, arguments);
     char* value;
     split(command, &value, '=');
+
+    static std::string last_mode;
+    static std::string last_ssid;
+    static std::string last_connected;
+    static std::string last_ip;
+
     wifi_mode = value;
-    if (strcmp(value, "No Wifi") != 0) {
-        parse_wifi(arguments);
-        current_scene->reDisplay();
+    if (strcmp(value, "No Wifi") == 0) {
+        if (last_mode != wifi_mode) {
+            last_mode = wifi_mode;
+            request_redisplay();
+        }
+        return;
+    }
+
+    parse_wifi(arguments);
+
+    if (last_mode != wifi_mode || last_ssid != wifi_ssid || last_connected != wifi_connected || last_ip != wifi_ip) {
+        last_mode      = wifi_mode;
+        last_ssid      = wifi_ssid;
+        last_connected = wifi_connected;
+        last_ip        = wifi_ip;
+        dbg_printf("Mode %s %s\n", command, arguments);
+        request_redisplay();
     }
 }
 

--- a/src/FileParser.h
+++ b/src/FileParser.h
@@ -34,4 +34,13 @@ extern std::string wifi_mode, wifi_ip, wifi_connected, wifi_ssid;
 
 void init_listener();
 void init_file_list();
-bool receive_plain_json(const char* line);
+
+// True while the streaming JSON parser is mid-document (outer-brace
+// depth > 0). Used by handle_other() in FluidNCModel.cpp to route
+// continuation chunks of a multi-line response back to handle_json().
+bool json_in_progress();
+
+// Discard any in-flight JSON state. Call when a transport-level event
+// (socket close, "ok"/"error:" delimiter, $-response) ends the document
+// abruptly so the next legitimate document starts with a clean parser.
+void json_reset_depth();

--- a/src/FileParser.h
+++ b/src/FileParser.h
@@ -44,3 +44,9 @@ bool json_in_progress();
 // (socket close, "ok"/"error:" delimiter, $-response) ends the document
 // abruptly so the next legitimate document starts with a clean parser.
 void json_reset_depth();
+
+// Called from show_error when FluidNC returns a bare "error:N" (no JSON
+// wrapper, as Telnet does). Advances the macro file chain so the
+// "Reading Macros" UI doesn't hang when a $File/SendJSON request was
+// rejected. No-op if no file request is currently in flight.
+extern "C" void file_request_failed_advance();

--- a/src/FirstBootScene.cpp
+++ b/src/FirstBootScene.cpp
@@ -1,7 +1,7 @@
 // 2026 - Figamore
 // FirstBootScene.cpp — one-time setup wizard shown on first boot.
 //
-// Asks the user to choose WiFi (WebSocket) or UART (serial cable).
+// Asks the user to choose WiFi (Telnet) or UART (serial cable).
 // Choice is saved to NVS, then transitions directly to the appropriate scene.
 
 #ifdef USE_WIFI
@@ -31,7 +31,7 @@ class FirstBootScene : public Scene {
     void onWifiPress() {
         if (!selectable())
             return;
-        wifi_set_uart_mode(false);  // WiFi / WebSocket
+        wifi_set_uart_mode(false);  // WiFi / Telnet
         first_boot_complete();
     }
 
@@ -53,7 +53,7 @@ public:
     void onGreenButtonPress() override {
         if (!selectable())
             return;
-        wifi_set_uart_mode(false);  // WiFi / WebSocket
+        wifi_set_uart_mode(false);  // WiFi / Telnet
         first_boot_complete();
     }
 

--- a/src/FluidNCModel.cpp
+++ b/src/FluidNCModel.cpp
@@ -257,6 +257,9 @@ extern "C" void handle_other(char* line) {
         handle_json(line);
         return;
     }
+#ifdef FNC_RX_TRACE
+    dbg_printf("[rx-other] %.120s%s\n", line, strlen(line) > 120 ? "..." : "");
+#endif
     int alarmlen = strlen("Active alarm: ");
     if (strncmp(line, "Active alarm: ", alarmlen) == 0) {
         lastAlarm = atoi(line + alarmlen);
@@ -269,6 +272,9 @@ extern "C" void handle_other(char* line) {
 }
 
 extern "C" void show_error(int error) {
+#ifdef FNC_RX_TRACE
+    dbg_printf("[rx-err] error:%d\n", error);
+#endif
     errorExpire = milliseconds() + 1000;
     lastError   = error;
     if (json_in_progress()) {
@@ -286,6 +292,9 @@ extern "C" void show_timeout() {
     dbg_println("Timeout");
 }
 extern "C" void show_ok() {
+#ifdef FNC_RX_TRACE
+    dbg_printf("[rx-ok]\n");
+#endif
     if (json_in_progress()) {
         // "ok" ends a reply; if a torn JSON doc was in flight, clean up.
         json_reset_depth();

--- a/src/FluidNCModel.cpp
+++ b/src/FluidNCModel.cpp
@@ -9,6 +9,11 @@
 #include "Scene.h"
 #include "e4math.h"
 #include "HomingScene.h"
+#include "BootLog.h"
+
+#ifdef USE_WIFI
+#    include "WiFiConnection.h"  // wifi_use_uart_mode()
+#endif
 
 extern Scene statusScene;
 
@@ -206,10 +211,11 @@ bool    awaiting_alarm = false;
 // Called once when status report received after being disconnected.
 // Use schedule_action() to defer execution to dispatch_events() in the main loop where the parser is idle and _report is clean.
 static void connect_init() {
+    bootlog_printf("connected: state=%s", my_state_string);
+    resetFlowControl();                  // clear any stale XOFF on the link
 #ifndef USE_WIFI
     fnc_realtime((realtime_cmd_t)0x0c);  // Ctrl-L - echo off (UART only)
 #endif
-    send_line("$G");                     // Refresh GCode modes
     send_line("$G");                     // Refresh GCode modes
     send_line("$RI=200");                // Enable auto-reporting every 200 ms
     init_file_list();                    // Request SD file list
@@ -306,10 +312,110 @@ const int disconnect_interval_ms = 6000;
 
 bool starting = true;
 
+// Counts consecutive disconnect_ms timeouts without RX, for the recovery ladder.
+static int s_consecutive_timeouts = 0;
+
+// Set by pendant_wait_for_fluidnc_ready() so fnc_is_connected() does not
+// immediately fire a redundant ping right after a successful handshake.
+static bool s_skip_first_ping = false;
+
 void request_status_report() {
     fnc_putchar(0x11);           // XON; request software flow control
     fnc_realtime(StatusReport);  // Request fresh status
     next_ping_ms = milliseconds() + ping_interval_ms;
+}
+
+// Drain bytes until the RX line has been quiet for `quiet_ms`, OR until
+// `max_total_ms` of wall time has elapsed (safety cap so a chatty
+// peer can never wedge us). Bytes are discarded, NOT fed to the parser.
+int flush_fnc_rx(uint32_t quiet_ms) {
+    const uint32_t max_total_ms = 500;
+    int            drained      = 0;
+    uint32_t       start        = milliseconds();
+    uint32_t       quiet_until  = start + quiet_ms;
+    while ((int32_t)(milliseconds() - quiet_until) < 0) {
+        if ((milliseconds() - start) >= max_total_ms) {
+            break;
+        }
+        int c = fnc_getchar();
+        if (c >= 0) {
+            drained++;
+            quiet_until = milliseconds() + quiet_ms;
+        }
+    }
+    return drained;
+}
+
+// Probe FluidNC over UART until it answers, OR `budget_ms` elapses.
+//
+// IMPORTANT: bytes read here are DISCARDED, not fed to the parser.
+// This function runs from setup() before activate_scene() has set
+// current_scene, and many vendor parser callbacks (show_state, show_dro,
+// show_alarm, show_error) eventually call current_scene methods. Feeding
+// bytes to the parser before current_scene is set would crash on the
+// first valid status report.
+bool pendant_wait_for_fluidnc_ready(uint32_t budget_ms) {
+    const uint32_t probe_window_ms = 500;
+    const uint32_t probe_gap_ms    = 200;
+
+    bootlog_printf("wait_ready: start budget=%lu", (unsigned long)budget_ms);
+
+    int drained = flush_fnc_rx(50);
+    bootlog_printf("wait_ready: drained=%d", drained);
+
+    uint32_t deadline = milliseconds() + budget_ms;
+    int      probe    = 0;
+    int      total_rx = 0;
+    while ((int32_t)(milliseconds() - deadline) < 0) {
+        probe++;
+        fnc_putchar(0x11);           // XON to clear any stale XOFF on FluidNC
+        fnc_realtime(StatusReport);  // '?' probe
+
+        int      window_rx  = 0;
+        uint32_t window_end = milliseconds() + probe_window_ms;
+        while ((int32_t)(milliseconds() - window_end) < 0) {
+            int c = fnc_getchar();
+            if (c >= 0) {
+                window_rx++;  // discard byte; do not feed parser yet
+            } else {
+                delay_ms(2);
+            }
+        }
+        total_rx += window_rx;
+        if (window_rx > 0) {
+            bootlog_printf("wait_ready: alive probe=%d bytes=%d", probe, window_rx);
+            s_skip_first_ping = true;
+            return true;
+        }
+        bootlog_printf("wait_ready: probe %d silent", probe);
+        delay_ms(probe_gap_ms);
+    }
+    bootlog_printf("wait_ready: timeout probes=%d rx=%d", probe, total_rx);
+    return false;
+}
+
+// Escalating recovery when the link has gone silent. Counter ticks once
+// per disconnect_interval_ms with no RX.
+//   tick 1: drain stale RX and send XON + status request.
+//   tick 3: re-initialize the UART driver from scratch, then re-probe.
+//           UART re-init is a no-op when running in WiFi mode.
+static void recover_link(int tick) {
+    bootlog_printf("recover: tick=%d", tick);
+    flush_fnc_rx(20);
+    request_status_report();
+    if (tick == 3) {
+#ifdef USE_WIFI
+        if (wifi_use_uart_mode()) {
+            bootlog_printf("recover: re-init uart");
+            reinit_fnc_uart();
+            request_status_report();
+        }
+#else
+        bootlog_printf("recover: re-init uart");
+        reinit_fnc_uart();
+        request_status_report();
+#endif
+    }
 }
 
 bool fnc_is_connected() {
@@ -320,10 +426,19 @@ bool fnc_is_connected() {
     if (starting) {
         starting      = false;
         disconnect_ms = now + (disconnect_interval_ms - ping_interval_ms);
-        request_status_report();  // sets next_ping_ms
+        if (s_skip_first_ping) {
+            // Handshake already got a response; let the regular ping cadence resume.
+            s_skip_first_ping = false;
+            next_ping_ms      = now + ping_interval_ms;
+        } else {
+            request_status_report();  // sets next_ping_ms
+        }
         return false;             // Do we need a value for "unknown"?
     }
     if ((now - disconnect_ms) >= 0) {
+        s_consecutive_timeouts++;
+        bootlog_printf("disconnected: timeout #%d", s_consecutive_timeouts);
+        recover_link(s_consecutive_timeouts);
         next_ping_ms  = now + ping_interval_ms;
         disconnect_ms = now + disconnect_interval_ms;
         return false;
@@ -339,4 +454,5 @@ void update_rx_time() {
     int now       = milliseconds();
     next_ping_ms  = now + ping_interval_ms;
     disconnect_ms = now + disconnect_interval_ms;
+    s_consecutive_timeouts = 0;
 }

--- a/src/FluidNCModel.cpp
+++ b/src/FluidNCModel.cpp
@@ -255,7 +255,7 @@ extern "C" void handle_other(char* line) {
 extern "C" void show_error(int error) {
     errorExpire = milliseconds() + 1000;
     lastError   = error;
-    current_scene->reDisplay();
+    request_redisplay();
 }
 
 extern "C" void show_timeout() {
@@ -269,7 +269,7 @@ extern "C" void end_status_report() {
 
 extern "C" void show_alarm(int alarm) {
     lastAlarm = alarm;
-    current_scene->reDisplay();
+    request_redisplay();
 }
 
 extern "C" void show_gcode_modes(struct gcode_modes* modes) {
@@ -290,7 +290,7 @@ extern "C" void show_gcode_modes(struct gcode_modes* modes) {
     }
 
     mySelectedTool = modes->tool;
-    current_scene->reDisplay();
+    request_redisplay();
 }
 
 int disconnect_ms = 0;

--- a/src/FluidNCModel.cpp
+++ b/src/FluidNCModel.cpp
@@ -239,12 +239,22 @@ extern "C" void show_state(const char* state_string) {
 }
 
 extern "C" void handle_other(char* line) {
-    // Intercept plain-JSON responses (FluidNC sends {"files":[...]} etc. without the [MSG:JSON:...] wrapper, sometimes split across frames).
-    if (receive_plain_json(line)) {
+    // $-responses are config, never JSON. If FluidNC tore down a JSON
+    // document by sending a $-response (rare, but happens on some error
+    // paths), drop the depth counter so the next document starts clean.
+    if (*line == '$') {
+        if (json_in_progress()) {
+            json_reset_depth();
+        }
+        parse_dollar(line);
         return;
     }
-    if (*line == '$') {
-        parse_dollar(line);
+    // Route to the streaming JSON parser if either (a) this line opens a
+    // new JSON object, or (b) a previous chunk left the outer brace open.
+    // FluidNC sends {"files":[...]} etc. without the [MSG:JSON:...] wrapper
+    // and splits the body across multiple lines for large file/macro lists.
+    if (*line == '{' || json_in_progress()) {
+        handle_json(line);
         return;
     }
     int alarmlen = strlen("Active alarm: ");
@@ -261,13 +271,22 @@ extern "C" void handle_other(char* line) {
 extern "C" void show_error(int error) {
     errorExpire = milliseconds() + 1000;
     lastError   = error;
+    if (json_in_progress()) {
+        // "error:N" without a JSON wrapper ends an in-flight document.
+        json_reset_depth();
+    }
     request_redisplay();
 }
 
 extern "C" void show_timeout() {
     dbg_println("Timeout");
 }
-extern "C" void show_ok() {}
+extern "C" void show_ok() {
+    if (json_in_progress()) {
+        // "ok" ends a reply; if a torn JSON doc was in flight, clean up.
+        json_reset_depth();
+    }
+}
 
 extern "C" void end_status_report() {
     current_scene->onDROChange();

--- a/src/FluidNCModel.cpp
+++ b/src/FluidNCModel.cpp
@@ -275,6 +275,10 @@ extern "C" void show_error(int error) {
         // "error:N" without a JSON wrapper ends an in-flight document.
         json_reset_depth();
     }
+    // Telnet returns bare "error:N" with no JSON wrapper when $File/SendJSON
+    // is rejected (file not present, etc). Without this hook the macro chain
+    // sits on "Reading Macros" forever because endDocument never fires.
+    file_request_failed_advance();
     request_redisplay();
 }
 

--- a/src/FluidNCModel.h
+++ b/src/FluidNCModel.h
@@ -62,5 +62,11 @@ void set_disconnected_state();
 
 void update_rx_time();
 
+// Bounded boot-time probe over UART: discards bootloader noise then sends
+// XON + status-report queries until FluidNC responds, or `budget_ms`
+// elapses. Returns true on response. Bytes read here are discarded, NOT
+// fed to the parser — current_scene may not be set yet at boot time.
+bool pendant_wait_for_fluidnc_ready(uint32_t budget_ms);
+
 extern pos_t toMm(pos_t position);
 extern pos_t fromMm(pos_t position);

--- a/src/Hardware2432.cpp
+++ b/src/Hardware2432.cpp
@@ -442,6 +442,10 @@ void init_hardware() {
 #endif
 }
 
+void reinit_fnc_uart() {
+    init_fnc_uart(FNC_UART_NUM, PND_TX_FNC_RX_PIN, PND_RX_FNC_TX_PIN);
+}
+
 int last_locked = -1;
 
 void redrawButtons() {

--- a/src/HardwareM5Dial.cpp
+++ b/src/HardwareM5Dial.cpp
@@ -64,6 +64,10 @@ void init_hardware() {
     touch.setFlickThresh(30);
 }
 
+void reinit_fnc_uart() {
+    init_fnc_uart(FNC_UART_NUM, PND_TX_FNC_RX_PIN, PND_RX_FNC_TX_PIN);
+}
+
 Point sprite_offset { 0, 0 };
 
 void show_logo() {

--- a/src/HomingScene.cpp
+++ b/src/HomingScene.cpp
@@ -25,7 +25,7 @@ bool is_homed(int axis) {
 }
 void set_axis_homed(int axis) {
     homed_axes |= 1 << axis;
-    current_scene->reDisplay();
+    request_redisplay();
 }
 
 void detect_homing_info() {

--- a/src/MacroMenu.cpp
+++ b/src/MacroMenu.cpp
@@ -11,7 +11,31 @@ extern Scene filePreviewScene;
 
 void MacroItem::invoke(void* arg) {
     if (arg && strcmp((char*)arg, "Run") == 0) {
-        send_linef("$Localfs/Run=%s", _filename.c_str());
+        if (_filename.rfind("cmd:", 0) == 0) {
+            // Split on \n, \r, and ';' — FluidNC parses ';' as a line-comment,
+            // so multi-statement macros like "G0 Z45; G0 Y166" must be sent as
+            // separate lines. Trim whitespace and skip empty segments.
+            const char* body = _filename.c_str() + 4;  // strip "cmd:" prefix
+            std::string line;
+            for (const char* p = body;; ++p) {
+                char c = *p;
+                if (c == '\n' || c == '\r' || c == ';' || c == '\0') {
+                    size_t start = line.find_first_not_of(" \t");
+                    if (start != std::string::npos) {
+                        size_t end = line.find_last_not_of(" \t");
+                        send_line(line.substr(start, end - start + 1).c_str());
+                    }
+                    line.clear();
+                    if (c == '\0') {
+                        break;
+                    }
+                } else {
+                    line.push_back(c);
+                }
+            }
+        } else {
+            send_linef("$Localfs/Run=%s", _filename.c_str());
+        }
     } else {
         push_scene(&filePreviewScene, (void*)_filename.c_str());
         // doFileScreen(_name);

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -157,6 +157,31 @@ void schedule_action(ActionHandler _action) {
     action = _action;
 }
 
+// Coalesced redraw bookkeeping. See Scene.h for rationale.
+static volatile bool s_redisplay_dirty   = false;
+static uint32_t      s_last_redisplay_ms = 0;
+
+void request_redisplay() {
+    s_redisplay_dirty = true;
+}
+
+void service_redisplay() {
+    if (!s_redisplay_dirty) {
+        return;
+    }
+    uint32_t now = millis();
+    // Cap UI refresh to UPDATE_RATE_MS (~30 ms). Multiple parser callbacks
+    // in the same window collapse to one reDisplay.
+    if ((int32_t)(now - s_last_redisplay_ms) < (int32_t)UPDATE_RATE_MS) {
+        return;
+    }
+    s_redisplay_dirty   = false;
+    s_last_redisplay_ms = now;
+    if (current_scene) {
+        current_scene->reDisplay();
+    }
+}
+
 void dispatch_events() {
     update_events();
 

--- a/src/Scene.h
+++ b/src/Scene.h
@@ -112,6 +112,20 @@ void rotateNumberLoop(T& currentVal, T increment, T min, T max) {
 typedef void (*ActionHandler)(void);
 void schedule_action(ActionHandler action);
 
+// Coalesced redraw request. Parser callbacks (show_state, show_alarm,
+// show_gcode_modes, handle_msg, set_axis_homed, ...) run inside fnc_poll
+// on the receive path. Calling current_scene->reDisplay() directly from
+// there means every incoming message triggers a full screen redraw —
+// which on the menu scene decodes 7+ PNGs from LittleFS, fragments the
+// heap allocator, and starves WiFi RX / touch handling.
+//
+// Use request_redisplay() instead. It sets a dirty flag; service_redisplay()
+// runs once per main-loop tick (rate-limited to UPDATE_RATE_MS) and issues
+// a single coalesced reDisplay if anything asked for one. Multiple requests
+// in the same tick collapse to one redraw.
+void request_redisplay();
+void service_redisplay();
+
 extern Scene* current_scene;
 
 void dispatch_events();

--- a/src/System.h
+++ b/src/System.h
@@ -71,6 +71,11 @@ void delay_ms(uint32_t ms);
 
 void resetFlowControl();
 
+// Re-initialize the FluidNC UART driver. Hardware-specific; called from the
+// link-recovery ladder in fnc_is_connected() when the link has gone silent
+// long enough that draining + re-probing didn't help.
+void reinit_fnc_uart();
+
 extern bool round_display;
 
 void system_background();

--- a/src/SystemArduino.cpp
+++ b/src/SystemArduino.cpp
@@ -71,9 +71,9 @@ extern "C" int  fnc_getchar()          { return uart_getchar_impl(); }
 #endif
 
 // poll_extra: called by fnc_poll() inside fnc_send_line()'s blocking wait loop.
-// In WiFi mode this MUST drive the WebSocket so that the "ok" response from
-// FluidNC can arrive in _rx_buf — otherwise fnc_send_line() blocks for the
-// full 2000 ms timeout on every second jog command, causing the stall.
+// In WiFi mode this MUST drive wifi_poll() so the Telnet socket refills _rx_buf
+// and the "ok" response from FluidNC can be observed — otherwise fnc_send_line()
+// blocks for the full 2000 ms timeout on every second jog command.
 extern "C" void poll_extra() {
 #ifdef USE_WIFI
     wifi_poll();
@@ -156,7 +156,7 @@ void init_system() {
 }
 void resetFlowControl() {
 #ifdef USE_WIFI
-    if (!wifi_use_uart_mode()) return;  // no-op over WebSocket
+    if (!wifi_use_uart_mode()) return;  // no-op over WiFi/Telnet
 #endif
     fnc_putchar(0x11);
     uart_ll_force_xon(fnc_uart_port);

--- a/src/SystemArduino.cpp
+++ b/src/SystemArduino.cpp
@@ -6,6 +6,7 @@
 #include "System.h"
 #include "FluidNCModel.h"
 #include "NVS.h"
+#include "BootLog.h"
 
 #include <Esp.h>  // ESP.restart()
 
@@ -138,6 +139,7 @@ void init_fnc_uart(int uart_num, int tx_pin, int rx_pin) {
     uart_set_sw_flow_ctrl(fnc_uart_port, true, 64, 120);
     uint32_t baud;
     uart_get_baudrate(fnc_uart_port, &baud);
+    bootlog_printf("uart: num=%d tx=%d rx=%d baud=%lu", uart_num, tx_pin, rx_pin, (unsigned long)baud);
 }
 
 void init_system() {

--- a/src/SystemMacOS.cpp
+++ b/src/SystemMacOS.cpp
@@ -114,6 +114,7 @@ int32_t layout_num  = 0;
 void    next_layout(int delta) {}
 
 void resetFlowControl() {}
+void reinit_fnc_uart() {}
 
 extern "C" void fnc_putchar(uint8_t c) {
     if (serial_fd >= 0) {

--- a/src/SystemMacOS_CYD.cpp
+++ b/src/SystemMacOS_CYD.cpp
@@ -201,6 +201,7 @@ extern "C" int fnc_getchar() {
 extern "C" void poll_extra() {}
 
 void resetFlowControl() {}
+void reinit_fnc_uart() {}
 
 void dbg_write(uint8_t c) {
     putchar(c);

--- a/src/SystemWindows.cpp
+++ b/src/SystemWindows.cpp
@@ -286,6 +286,7 @@ void base_display() {
 void next_layout(int delta) {}
 
 void resetFlowControl() {}
+void reinit_fnc_uart() {}
 
 extern "C" void fnc_putchar(uint8_t c) {
     serial_write(hFNC, &c, 1);

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -302,15 +302,28 @@ static bool ws_send_bin(const uint8_t* payload, size_t length) {
 }
 
 // Pull bytes off the socket and push them into the RX ring buffer. Called
-// from wifi_poll() — non-blocking. Splits the kernel buffer into chunks so
-// the ring buffer never overruns.
+// from wifi_poll() — non-blocking. Bounded by available ring space so a
+// burst from FluidNC (preferences.json is ~5 KB and arrives in one shot)
+// can't overflow the ring and silently drop bytes mid-document, which
+// corrupts the streaming JSON parser. Any data we don't read stays in
+// the kernel's TCP receive window; TCP flow control will pause FluidNC
+// if we fall too far behind.
 static void tcp_refill_rx() {
     if (_sock < 0) {
         return;
     }
     uint8_t buf[256];
     while (true) {
-        ssize_t n = ::recv(_sock, buf, sizeof(buf), MSG_DONTWAIT);
+        // Compute headroom in the ring buffer (leave one slot empty to
+        // distinguish full from empty). If we'd overrun, stop and let
+        // fnc_poll drain some bytes first.
+        int used = (_rx_head - _rx_tail + RX_BUF_SIZE) % RX_BUF_SIZE;
+        int free = RX_BUF_SIZE - used - 1;
+        if (free <= 0) {
+            return;
+        }
+        size_t want = (size_t)free < sizeof(buf) ? (size_t)free : sizeof(buf);
+        ssize_t n = ::recv(_sock, buf, want, MSG_DONTWAIT);
         if (n <= 0) {
             if (n == 0) {
                 dbg_println("Telnet: peer closed");
@@ -329,8 +342,8 @@ static void tcp_refill_rx() {
             rx_push(c);
         }
         update_rx_time();
-        if ((size_t)n < sizeof(buf)) {
-            // Kernel had less than a full buffer ready; nothing more for now.
+        if ((size_t)n < want) {
+            // Kernel had less than we asked for; nothing more for now.
             return;
         }
     }

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -11,7 +11,7 @@
 #include "WiFiConnection.h"
 #include "FluidNCModel.h"
 #include "System.h"
-#include "Scene.h"   // current_scene->reDisplay()
+#include "Scene.h"   // request_redisplay()
 
 #include <Esp.h>
 #include <WiFi.h>
@@ -253,7 +253,7 @@ static void onWsEvent(WStype_t type, uint8_t* payload, size_t length) {
             _last_status_ms = 0;
             dbg_printf("WS: connected to FluidNC at ws://%s:%d%s\n", _active_cfg.fluidnc_ip, FLUIDNC_WS_PORT, FLUIDNC_WS_PATH);
             // Update the badge immediately; state report from FluidNC will follow shortly.
-            current_scene->reDisplay();
+            request_redisplay();
             break;
         }
 
@@ -684,7 +684,7 @@ void wifi_init(bool auto_ap) {
             // via browser immediately (captive portal at 192.168.4.1).
             dbg_println("No WiFi credentials — starting AP setup mode automatically");
             wifi_start_ap_setup();
-            current_scene->reDisplay();  // switch scene from "not configured" to AP view
+            request_redisplay();  // switch scene from "not configured" to AP view
         }
         return;
     }
@@ -754,7 +754,7 @@ void wifi_poll() {
     if (!_wifi_ever_connected && !_wifi_error_msg && _wifi_connect_start_ms &&
         (millis() - _wifi_connect_start_ms) > WIFI_CONNECT_TIMEOUT_MS) {
         _wifi_error_msg = "Cannot connect";
-        current_scene->reDisplay();
+        request_redisplay();
     }
 
     // Decode the reason code set by the WiFi disconnect event.
@@ -814,7 +814,7 @@ void wifi_poll() {
                 if (allow_retry && !_wifi_retry_at) {
                     _wifi_retry_at = millis() + WIFI_RETRY_DELAY_MS;
                 }
-                if (changed) current_scene->reDisplay();
+                if (changed) request_redisplay();
             }
         }
     }
@@ -850,7 +850,7 @@ void wifi_poll() {
             start_dns_resolve();
         }
         // WiFi just came up — update badge from "WiFi..." to "WiFi OK".
-        current_scene->reDisplay();
+        request_redisplay();
     }
     if (!now_connected && _wifi_was_connected) {
         if (_ws_started) {
@@ -879,7 +879,7 @@ void wifi_poll() {
             _wifi_error_msg = "Host not found";
             _dns_retry_at   = millis() + DNS_RETRY_DELAY_MS;
         }
-        current_scene->reDisplay();
+        request_redisplay();
     }
 
     // Retry DNS resolution after a failed attempt (ie: FluidNC may not have
@@ -890,7 +890,7 @@ void wifi_poll() {
         _wifi_error_msg = nullptr;
         dbg_printf("DNS retry: resolving %s\n", _active_cfg.fluidnc_ip);
         start_dns_resolve();
-        current_scene->reDisplay();
+        request_redisplay();
     }
 
     if (_ws_started) {
@@ -904,7 +904,7 @@ void wifi_poll() {
         uint32_t        now_ms        = millis();
         if (now_ms - _last_anim_ms >= 400) {
             _last_anim_ms = now_ms;
-            current_scene->reDisplay();
+            request_redisplay();
         }
         return;
     }

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -13,6 +13,7 @@
 
 #include "WiFiConnection.h"
 #include "FluidNCModel.h"
+#include "FileParser.h"  // json_reset_depth()
 #include "System.h"
 #include "Scene.h"   // request_redisplay()
 
@@ -166,6 +167,9 @@ static void tcp_close() {
         _sock = -1;
     }
     _ws_connected = false;
+    // Any JSON document still being streamed across chunks is now lost;
+    // reset the depth tracker so the next document starts cleanly.
+    json_reset_depth();
 }
 
 static void tcp_apply_opts(int fd) {

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -25,6 +25,7 @@
 
 #include <lwip/sockets.h>
 #include <lwip/netdb.h>
+#include <mdns.h>          // mdns_query_a() — ESP-IDF multicast DNS
 #include <fcntl.h>
 #include <errno.h>
 
@@ -94,11 +95,45 @@ static bool is_dotted_decimal(const char* s) {
     return true;
 }
 
+// Resolve a hostname to an IPv4 address using the correct path for the
+// name shape:
+//   *.local  → ESP-IDF mdns_query_a (multicast).
+//   anything else → unicast DNS via lwip / WiFi.hostByName.
+// WiFi.hostByName() tries unicast first then mDNS, which is the wrong
+// order for .local — unicast may resolve via a misconfigured upstream
+// resolver (or a router that hijacks .local), yielding a confidently
+// wrong address. Going straight to mdns_query_a avoids that.
+static bool resolve_host_strict(const char* host, IPAddress& out) {
+    size_t len = strlen(host);
+    const char* dot_local = ".local";
+    size_t dl_len = strlen(dot_local);
+    if (len > dl_len && strcasecmp(host + len - dl_len, dot_local) == 0) {
+        // Strip the .local suffix; mdns_query_a appends it internally.
+        char base[64];
+        size_t base_len = len - dl_len;
+        if (base_len >= sizeof(base)) {
+            return false;
+        }
+        memcpy(base, host, base_len);
+        base[base_len] = '\0';
+        esp_ip4_addr_t addr = {};
+        esp_err_t      err  = mdns_query_a(base, 2000, &addr);
+        if (err != ESP_OK) {
+            dbg_printf("mDNS: %s.local err=%d\n", base, (int)err);
+            return false;
+        }
+        out = IPAddress(addr.addr);
+        return true;
+    }
+    return WiFi.hostByName(host, out) == 1;
+}
+
 static void dnsResolveTask(void* /*param*/) {
     IPAddress ip;
-    // hostByName() blocks until the mDNS/DNS reply arrives or the stack times
-    // out — running it on a background task keeps the main loop responsive.
-    bool ok = (WiFi.hostByName(_active_cfg.fluidnc_ip, ip) == 1);
+    // resolve_host_strict() blocks on mDNS or unicast DNS depending on the
+    // hostname shape — running it on a background task keeps the main loop
+    // responsive while the multicast query waits up to 2 s for a reply.
+    bool ok = resolve_host_strict(_active_cfg.fluidnc_ip, ip);
     if (ok) {
         ip.toString().toCharArray(_dns_result_str, sizeof(_dns_result_str));
     }

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -1,10 +1,13 @@
-// 2026 - Figamore
+// 2026 - Figamore (original WebSocket scaffolding)
+// 2026 - Paul Mokbel (Telnet transport)
 // Use of this source code is governed by a GPLv3 license.
 //
-// WiFi / WebSocket transport layer for FluidDial.
+// WiFi transport layer for FluidDial.
 //
-// Provides fnc_putchar() and fnc_getchar() over a WebSocket connection to
-// FluidNC instead of UART.
+// Provides fnc_putchar() and fnc_getchar() over a raw TCP (Telnet) socket
+// to FluidNC on port 23. The public API still carries `ws_*` and `*_ws_*`
+// names because the surrounding scenes were already wired against them;
+// the implementation underneath is lwip sockets, not WebSocket.
 
 #ifdef ARDUINO
 
@@ -16,19 +19,21 @@
 #include <Esp.h>
 #include <WiFi.h>
 #include <ESPmDNS.h>
-#include <WebSocketsClient.h>
 #include <WebServer.h>
 #include <DNSServer.h>
 #include <Preferences.h>
+
+#include <lwip/sockets.h>
+#include <lwip/netdb.h>
+#include <fcntl.h>
+#include <errno.h>
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 
 #define WIFI_AP_SSID       "FluidDial"
 #define WIFI_AP_PASS       ""          // Open AP — no password needed
 #define PREF_NAMESPACE     "fluidwifi"
-#define WS_SUBPROTOCOL     "arduino"
-#define FLUIDNC_WS_PORT    80
-#define FLUIDNC_WS_PATH    "/"
+#define FLUIDNC_TELNET_PORT 23
 #define HARDCODE_TEST_WIFI 0
 #define TEST_WIFI_SSID     "FluidNC"
 #define TEST_WIFI_PASS     "12345678"
@@ -38,10 +43,13 @@
 #define STATUS_POLL_MS     500         // Send '?' every 500 ms while connected
 #define WIFI_RETRY_DELAY_MS 15000     // Retry WiFi.begin() this long after a failure
 #define DNS_RETRY_DELAY_MS  5000     // Retry hostname resolution this long after a failure
+#define TCP_RECONNECT_DELAY_MS 2000   // Retry TCP connect this long after a failure
 
 // ─── Globals ─────────────────────────────────────────────────────────────────
 
-static WebSocketsClient webSocket;
+static int              _sock = -1;
+static uint32_t         _tcp_next_try_ms = 0;
+static char             _fluidnc_remote_ip[40] = {};  // dotted-decimal, cached for reconnects
 static WebServer        httpServer(80);
 static DNSServer        dnsServer;
 
@@ -59,8 +67,8 @@ static bool             _wifi_ever_connected      = false;    // true once WL_CO
 static uint32_t         _wifi_connect_start_ms    = 0;        // millis() when WiFi.begin() was last issued
 static uint8_t          _handshake_timeout_count  = 0;        // consecutive 4-way handshake timeouts; real auth fail after threshold
 
-// Ring buffer for characters received from FluidNC via WebSocket.
-// Written in the WS callback, read by fnc_getchar() (both on the main task).
+// Ring buffer for characters received from FluidNC over Telnet.
+// Refilled by tcp_refill_rx() from wifi_poll(); read by fnc_getchar().
 static uint8_t _rx_buf[RX_BUF_SIZE];
 static int     _rx_head = 0;
 static int     _rx_tail = 0;
@@ -85,8 +93,6 @@ static bool is_dotted_decimal(const char* s) {
     }
     return true;
 }
-
-static void onWsEvent(WStype_t type, uint8_t* payload, size_t length);
 
 static void dnsResolveTask(void* /*param*/) {
     IPAddress ip;
@@ -115,13 +121,83 @@ static void start_dns_resolve() {
     }
 }
 
-static void ws_begin(const char* host) {
-    dbg_printf("Starting WebSocket: ws://%s:%d%s\n", host, FLUIDNC_WS_PORT, FLUIDNC_WS_PATH);
-    webSocket.begin(host, FLUIDNC_WS_PORT, FLUIDNC_WS_PATH, WS_SUBPROTOCOL);
-    webSocket.onEvent(onWsEvent);
-    webSocket.setReconnectInterval(3000);
-    webSocket.enableHeartbeat(5000, 2000, 1);
+// Ring buffer push/pop are defined further down; forward-declare so
+// tcp_refill_rx() can push received bytes from up here.
+static inline void rx_push(uint8_t c);
+
+static void tcp_close() {
+    if (_sock >= 0) {
+        ::close(_sock);
+        _sock = -1;
+    }
+    _ws_connected = false;
+}
+
+static void tcp_apply_opts(int fd) {
+    // TCP_NODELAY: send realtime ('?', '!', '~', XON, etc.) as their own
+    // segments instead of waiting for Nagle to coalesce.
+    int one = 1;
+    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+
+    // Bound how long a blocking send() will wait if FluidNC's RX is full.
+    struct timeval snd_tv = { 2, 0 };
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &snd_tv, sizeof(snd_tv));
+
+    // Detect dead peers faster than the default ~2 hour kernel timeout.
+    int keepalive  = 1;
+    int idle_s     = 10;
+    int interval_s = 3;
+    int count      = 3;
+    setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive));
+    setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &idle_s, sizeof(idle_s));
+    setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &interval_s, sizeof(interval_s));
+    setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &count, sizeof(count));
+}
+
+// Open a raw TCP socket to FluidNC's telnet server (port 23). Synchronous;
+// returns true on success. Called from wifi_poll() once WiFi STA is up and
+// the FluidNC IP has been resolved.
+static bool tcp_open(const char* host) {
+    dbg_printf("Starting Telnet: %s:%d\n", host, FLUIDNC_TELNET_PORT);
+    IPAddress ip;
+    if (!ip.fromString(host)) {
+        dbg_printf("Telnet: bad IP literal: %s\n", host);
+        return false;
+    }
+    int fd = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (fd < 0) {
+        dbg_printf("Telnet: socket errno=%d\n", errno);
+        return false;
+    }
+    struct sockaddr_in dest;
+    memset(&dest, 0, sizeof(dest));
+    dest.sin_family      = AF_INET;
+    dest.sin_port        = htons(FLUIDNC_TELNET_PORT);
+    dest.sin_addr.s_addr = (uint32_t)ip;
+    if (::connect(fd, (struct sockaddr*)&dest, sizeof(dest)) != 0) {
+        dbg_printf("Telnet: connect errno=%d\n", errno);
+        ::close(fd);
+        return false;
+    }
+    tcp_apply_opts(fd);
+    _sock = fd;
+    _ws_connected   = true;
+    _last_status_ms = 0;
+    dbg_printf("Telnet: connected to %s:%d (fd=%d)\n", host, FLUIDNC_TELNET_PORT, fd);
+    request_redisplay();
+    return true;
+}
+
+static void tcp_begin(const char* host) {
+    // `host` is the resolved dotted-decimal IP (either from is_dotted_decimal
+    // shortcut or from start_dns_resolve()). Cache it so reconnects after a
+    // transient drop don't have to redo DNS for a still-valid host.
+    strncpy(_fluidnc_remote_ip, host, sizeof(_fluidnc_remote_ip) - 1);
+    _fluidnc_remote_ip[sizeof(_fluidnc_remote_ip) - 1] = '\0';
     _ws_started = true;
+    if (!tcp_open(host)) {
+        _tcp_next_try_ms = millis() + TCP_RECONNECT_DELAY_MS;
+    }
 }
 
 static const char* wifi_status_name(wl_status_t status) {
@@ -147,12 +223,78 @@ static const char* wifi_status_name(wl_status_t status) {
     }
 }
 
+// Bulk send over the raw socket. Blocks up to SO_SNDTIMEO per chunk;
+// transient EAGAIN drops the remainder of this flush but keeps the
+// socket so the in-flight document survives. Any other errno tears the
+// socket down so wifi_poll() can reconnect.
+static bool tcp_send_all(const uint8_t* payload, size_t length) {
+    if (_sock < 0 || length == 0) {
+        return _sock >= 0;
+    }
+    size_t off = 0;
+    while (off < length) {
+        ssize_t n = ::send(_sock, payload + off, length - off, 0);
+        if (n <= 0) {
+            int e = errno;
+            if (e == EAGAIN || e == EWOULDBLOCK) {
+                dbg_printf("Telnet: send EAGAIN dropped=%u of %u\n",
+                           (unsigned)(length - off), (unsigned)length);
+                return true;
+            }
+            dbg_printf("Telnet: send errno=%d off=%u/%u\n",
+                       e, (unsigned)off, (unsigned)length);
+            tcp_close();
+            set_disconnected_state();
+            return false;
+        }
+        off += (size_t)n;
+    }
+    return true;
+}
+
+// Keep the ws_send_text/ws_send_bin spellings for the ws_putchar
+// callsites — both go through the same raw send() now.
 static bool ws_send_text(uint8_t* payload, size_t length) {
-    return webSocket.sendTXT(payload, length);
+    return tcp_send_all(payload, length);
 }
 
 static bool ws_send_bin(const uint8_t* payload, size_t length) {
-    return webSocket.sendBIN(payload, length);
+    return tcp_send_all(payload, length);
+}
+
+// Pull bytes off the socket and push them into the RX ring buffer. Called
+// from wifi_poll() — non-blocking. Splits the kernel buffer into chunks so
+// the ring buffer never overruns.
+static void tcp_refill_rx() {
+    if (_sock < 0) {
+        return;
+    }
+    uint8_t buf[256];
+    while (true) {
+        ssize_t n = ::recv(_sock, buf, sizeof(buf), MSG_DONTWAIT);
+        if (n <= 0) {
+            if (n == 0) {
+                dbg_println("Telnet: peer closed");
+                tcp_close();
+                set_disconnected_state();
+            } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                dbg_printf("Telnet: recv errno=%d\n", errno);
+                tcp_close();
+                set_disconnected_state();
+            }
+            return;
+        }
+        for (ssize_t i = 0; i < n; i++) {
+            uint8_t c = buf[i];
+            if (c == '\r') continue;  // strip CR; GrblParserC wants LF-terminated lines
+            rx_push(c);
+        }
+        update_rx_time();
+        if ((size_t)n < sizeof(buf)) {
+            // Kernel had less than a full buffer ready; nothing more for now.
+            return;
+        }
+    }
 }
 
 // ─── Ring-buffer helpers ──────────────────────────────────────────────────────
@@ -172,20 +314,19 @@ static inline int rx_pop() {
     return (unsigned char)c;
 }
 
-// ─── WebSocket transport primitives ──────────────────────────────────────────
+// ─── Telnet transport primitives ─────────────────────────────────────────────
 // These are called by fnc_putchar/fnc_getchar (defined in SystemArduino.cpp)
-// when the active transport is WiFi.
+// when the active transport is WiFi. Kept under the ws_* spelling so the
+// SystemArduino dispatch and simulator stubs don't have to rename.
 
-// Send one byte to FluidNC via WebSocket.
+// Send one byte to FluidNC over the Telnet socket.
 void ws_putchar(uint8_t c) {
-    // Skip UART XON/XOFF flow-control bytes (irrelevant over WebSocket).
+    // Skip UART XON/XOFF flow-control bytes (irrelevant over TCP).
     if (c == 0x11 || c == 0x13) return;
 
     // Extended single-byte realtime commands: Ctrl-X, 0x80–0x9F, and the
-    // IO-extender commands 0xB0–0xB3 (ACK=0xB2, NAK=0xB3).  FluidNC uses
-    // ACK/NAK flow control when streaming JSON file listings, even over
-    // WebSocket — without it the first chunk arrives and FluidNC stalls
-    // waiting for acknowledgement, leaving the file list empty.
+    // IO-extender commands 0xB0–0xB3 (ACK=0xB2, NAK=0xB3). Send each one
+    // immediately so it doesn't sit behind buffered g-code text.
     if (c == 0x18 || (c >= 0x80 && c <= 0x9F) || (c >= 0xB0 && c <= 0xB3)) {
         if (_ws_connected) ws_send_bin(&c, 1);
         return;
@@ -207,7 +348,7 @@ void ws_putchar(uint8_t c) {
     }
 }
 
-// Receive one byte from the WebSocket ring buffer (-1 if empty).
+// Receive one byte from the RX ring buffer (-1 if empty).
 int ws_getchar() {
     return rx_pop();
 }
@@ -242,55 +383,6 @@ bool wifi_is_first_boot() {
     bool done = prefs.getBool("setup_done", false);
     prefs.end();
     return !done;
-}
-
-// ─── WebSocket event handler ──────────────────────────────────────────────────
-
-static void onWsEvent(WStype_t type, uint8_t* payload, size_t length) {
-    switch (type) {
-        case WStype_CONNECTED: {
-            _ws_connected = true;
-            _last_status_ms = 0;
-            dbg_printf("WS: connected to FluidNC at ws://%s:%d%s\n", _active_cfg.fluidnc_ip, FLUIDNC_WS_PORT, FLUIDNC_WS_PATH);
-            // Update the badge immediately; state report from FluidNC will follow shortly.
-            request_redisplay();
-            break;
-        }
-
-        case WStype_DISCONNECTED:
-            _ws_connected = false;
-            dbg_println("WS: disconnected from FluidNC");
-            set_disconnected_state();
-            break;
-
-        case WStype_TEXT:
-        case WStype_BIN: {
-            // Push every received byte into the ring buffer.
-            // GrblParserC's fnc_getchar() will drain it character-by-character.
-            for (size_t i = 0; i < length; i++) {
-                if (payload[i] == '\r') continue;  // Strip CR
-                rx_push(payload[i]);
-            }
-            // Ensure the last line is newline-terminated.
-            if (length > 0 && payload[length - 1] != '\n') {
-                rx_push('\n');
-            }
-            update_rx_time();
-            break;
-        }
-
-        case WStype_ERROR:
-            dbg_println("WS: error");
-            break;
-
-        case WStype_PING:
-        case WStype_PONG:
-        case WStype_FRAGMENT_TEXT_START:
-        case WStype_FRAGMENT_BIN_START:
-        case WStype_FRAGMENT:
-        case WStype_FRAGMENT_FIN:
-            break;
-    }
 }
 
 // ─── Captive portal HTML ──────────────────────────────────────────────────────
@@ -548,7 +640,7 @@ WiFiConfig wifi_load_config() {
 
 void wifi_start_ap_setup() {
     _ap_mode            = true;
-    _ws_connected       = false;
+    tcp_close();
     _ws_started         = false;
     _wifi_stack_started = true;  // ensure wifi_poll() drives DNS/HTTP server
 
@@ -611,11 +703,9 @@ bool websocket_is_connected() {
 
 void wifi_force_ws_reconnect() {
     if (_ws_started) {
-        webSocket.disconnect();
-        _ws_connected = false;
-        // Leave _ws_started true — WebSocketsClient will auto-reconnect
-        // on the next webSocket.loop() via setReconnectInterval().
-        dbg_println("WS: force-closed for reconnect");
+        tcp_close();
+        _tcp_next_try_ms = millis() + TCP_RECONNECT_DELAY_MS;
+        dbg_println("Telnet: force-closed for reconnect");
     }
 }
 
@@ -692,8 +782,10 @@ void wifi_init(bool auto_ap) {
     _wifi_stack_started = true;
     dbg_printf("Connecting to WiFi: %s  FluidNC: %s\n", cfg.ssid, cfg.fluidnc_ip);
     _active_cfg              = cfg;
+    tcp_close();
     _ws_started              = false;
-    _ws_connected            = false;
+    _tcp_next_try_ms         = 0;
+    _fluidnc_remote_ip[0]    = '\0';
     _wifi_was_connected      = false;
     _last_wifi_status        = WL_IDLE_STATUS;
     _wifi_error_msg          = nullptr;
@@ -832,7 +924,7 @@ void wifi_poll() {
         WiFi.begin(_active_cfg.ssid, _active_cfg.password[0] ? _active_cfg.password : nullptr);
     }
 
-    // Detect WiFi reconnects so the WebSocket can recover.
+    // Detect WiFi reconnects so the Telnet socket can be re-opened.
     bool now_connected = wifi_status == WL_CONNECTED;
     if (now_connected && !_wifi_was_connected) {
         dbg_printf("WiFi connected — IP: %s\n",
@@ -842,10 +934,10 @@ void wifi_poll() {
             dbg_println("mDNS init failed — .local hostnames may not resolve");
         }
         if (is_dotted_decimal(_active_cfg.fluidnc_ip)) {
-            // Plain IP address — start WebSocket immediately.
-            ws_begin(_active_cfg.fluidnc_ip);
+            // Plain IP address — open Telnet socket immediately.
+            tcp_begin(_active_cfg.fluidnc_ip);
         } else if (!_dns_resolving) {
-            // Hostname — resolve asynchronously; ws_begin() runs when done.
+            // Hostname — resolve asynchronously; tcp_begin() runs when done.
             _dns_retry_at = 0;  // cancel any pending retry from a prior failure
             start_dns_resolve();
         }
@@ -854,25 +946,24 @@ void wifi_poll() {
     }
     if (!now_connected && _wifi_was_connected) {
         if (_ws_started) {
-            webSocket.disconnect();
+            tcp_close();
             _ws_started = false;
         }
-        _dns_done     = false;  // discard any in-flight DNS result
-        _ws_connected = false;
+        _dns_done = false;  // discard any in-flight DNS result
         set_disconnected_state();
         dbg_println("WiFi lost");
     }
     _wifi_was_connected = now_connected;
 
     // Handle async DNS completion (hostname -> IP resolution).
-    // Only act if WiFi is still up and the WebSocket hasn't already started.
+    // Only act if WiFi is still up and the Telnet socket hasn't already started.
     if (_dns_done && !_ws_started && now_connected) {
         bool ok = _dns_ok;
         _dns_done = false;
         if (ok) {
             dbg_printf("Hostname resolved: %s -> %s\n",
                        _active_cfg.fluidnc_ip, _dns_result_str);
-            ws_begin(_dns_result_str);
+            tcp_begin(_dns_result_str);
         } else {
             dbg_printf("Hostname resolution failed: %s — retrying in %d ms\n",
                        _active_cfg.fluidnc_ip, DNS_RETRY_DELAY_MS);
@@ -893,9 +984,18 @@ void wifi_poll() {
         request_redisplay();
     }
 
-    if (_ws_started) {
-        // Drive the WebSocket state machine only after WiFi is up.
-        webSocket.loop();
+    // Service the Telnet socket: refill RX from the kernel buffer, and if
+    // the socket is down, attempt periodic reconnects.
+    if (_ws_started && now_connected) {
+        if (_sock >= 0) {
+            tcp_refill_rx();
+        } else if (_tcp_next_try_ms && (int32_t)(millis() - _tcp_next_try_ms) >= 0) {
+            _tcp_next_try_ms = 0;
+            dbg_println("Telnet: reconnect attempt");
+            if (!tcp_open(_fluidnc_remote_ip)) {
+                _tcp_next_try_ms = millis() + TCP_RECONNECT_DELAY_MS;
+            }
+        }
     }
 
     // Animate the connecting badge until FluidNC is fully connected.

--- a/src/ardmain.cpp
+++ b/src/ardmain.cpp
@@ -108,4 +108,5 @@ void loop() {
 #endif
     fnc_poll();         // Parse incoming bytes from FluidNC (UART or WebSocket)
     dispatch_events();  // Handle dial, touch, buttons
+    service_redisplay();
 }

--- a/src/ardmain.cpp
+++ b/src/ardmain.cpp
@@ -110,7 +110,14 @@ void loop() {
         wifi_poll();
     }
 #endif
-    fnc_poll();         // Parse incoming bytes from FluidNC (UART or WiFi/Telnet)
+    // fnc_poll() drains ONE byte per call. The WiFi transport can refill its
+    // ring buffer with hundreds of bytes per loop iteration (a kernel TCP
+    // window worth — preferences.json bursts in ~5 KB). Drain a chunk per
+    // tick so the ring buffer can't overflow and silently drop bytes,
+    // which corrupts the streaming JSON parser mid-document.
+    for (int i = 0; i < 64; i++) {
+        fnc_poll();
+    }
     dispatch_events();  // Handle dial, touch, buttons
     service_redisplay();
 }

--- a/src/ardmain.cpp
+++ b/src/ardmain.cpp
@@ -110,7 +110,7 @@ void loop() {
         wifi_poll();
     }
 #endif
-    fnc_poll();         // Parse incoming bytes from FluidNC (UART or WebSocket)
+    fnc_poll();         // Parse incoming bytes from FluidNC (UART or WiFi/Telnet)
     dispatch_events();  // Handle dial, touch, buttons
     service_redisplay();
 }

--- a/src/ardmain.cpp
+++ b/src/ardmain.cpp
@@ -3,6 +3,7 @@
 
 #include "System.h"
 #include "FileParser.h"
+#include "FluidNCModel.h"  // pendant_wait_for_fluidnc_ready()
 #include "Scene.h"
 #include "AboutScene.h"
 #ifdef USE_M5
@@ -60,10 +61,13 @@ void setup() {
     dbg_printf("FluidNC Pendant %s\n", git_info);
 
 #ifndef USE_WIFI
-    fnc_realtime(StatusReport);  // Kick FluidNC into action via UART
+    // Bounded boot probe — discards stale bootloader noise, asks FluidNC
+    // for a status report, waits up to 7 s for any RX byte. If it times
+    // out the runtime recovery ladder in fnc_is_connected() takes over.
+    pendant_wait_for_fluidnc_ready(7000);
 #else
     if (wifi_use_uart_mode()) {
-        fnc_realtime(StatusReport);  // UART mode in a WiFi build
+        pendant_wait_for_fluidnc_ready(7000);
     }
 #endif
 


### PR DESCRIPTION
## Summary

WiFi has been unreliable in multiple distinct ways. This PR refactors the FluidNC link from the WebSocket transport that landed in #49 to a raw TCP/lwip Telnet client on port 23, and fixes several layered communication and UX issues that were independently breaking the link — RX flow control, mDNS resolution, JSON streaming, redraw coalescing, macro-chain advance, boot/link recovery, and more. Even if the WebSocket had connected cleanly (it can't, on every FluidNC build I tested it returns ECONNRESET at TCP-connect time), the rest of these issues would still have surfaced.

The lwip/Telnet refactor was a strategic call rather than a forced one: FluidNC supports Telnet natively on port 23 without any server-side configuration, there's no HTTP upgrade handshake or WS framing overhead, fewer failure modes, and the pendant doesn't actually need any of WebSocket's features for this use case.

None of the changes are hardware-specific — they apply equally to M5 Dial, stock CYD, and any other CYD-based pendant. The fixes are organized into 10 logically-distinct commits so each can be reviewed (or reverted) independently. Each is described below in commit order.

## Commits

1. **Coalesce display redraws to avoid heap fragmentation under transport load** — Parser callbacks (`show_error`, `show_alarm`, `show_gcode_modes`, `handle_radio_mode`, `set_axis_homed`, etc.) and WiFi events no longer redraw the screen on every message. Refresh capped to ~30 ms via `request_redisplay()` + `service_redisplay()`. Eliminates flicker on both UART and WiFi; over WiFi this also prevents the heap-fragmentation OOM where mDNS dies within ~60 s of streaming.

2. **Add bounded boot handshake, escalating link recovery, and BootLog diagnostics** — Bounded boot probe (`pendant_wait_for_fluidnc_ready(7000)`) drains stale RX, sends XON + StatusReport, and waits up to 7 s for FluidNC's first byte. Escalating recovery ladder in `fnc_is_connected()` retries on disconnect (drain → reprobe → full `reinit_fnc_uart()` re-install on tick 3). `resetFlowControl()` + `$G` + `$RI=200` run on every Disconnected→Connected transition. `BootLog` ring buffer (48 timestamped lines) is viewable on AboutScene when the link is down.

3. **Run cmd-prefixed macros from preferences.json** — WebUI 3 stores `type:"CMD"` macros with their G-code inline; `PreferencesListener` adds them to the menu with a `cmd:` prefix, but `MacroItem::invoke()` sent every macro to `$Localfs/Run=%s` — including `cmd:` ones that aren't files. Now detects the prefix, strips it, splits on `\n` / `\r` / `;` (FluidNC parses `;` as a line-comment so multi-statement bodies must be sent as separate lines), trims whitespace, and sends each non-empty segment via `send_line()`.

4. **Drop per-chunk 0xB2 realtime ack from handle_json** — The vendor `realtime_cmd_t` enum documents `0xB2` as the IO Expander ACK byte, not a JSON-stream flow control. Sending it after every JSON chunk created constant outbound pressure that, on Telnet, filled the kernel TCP send buffer (EAGAIN), eventually tripped `SO_SNDTIMEO` / EHOSTUNREACH, and tore the connection down mid-document. FluidNC streams JSON fine without it.

5. **Replace WebSocket transport with raw TCP Telnet** — The WebSocket implementation that landed in #49 connects to `ws://<host>:80/` with subprotocol `"arduino"` and was rejected at TCP-connect time on every FluidNC build I tested (errno 104 ECONNRESET). FluidNC ships a Telnet server on port 23 out of the box; the pendant doesn't need WS framing, multiplexing, or the HTTP upgrade handshake. Swap to raw lwip TCP with `TCP_NODELAY`, `SO_SNDTIMEO=2s`, and TCP keepalive 10/3/3 so dead peers are detected faster than the kernel's 2-hour default. Runtime credentials (WiFiSetupScene + AP captive portal + NVS) preserved as-is.

6. **Resolve `*.local` hostnames via mdns_query_a** — `WiFi.hostByName()` tries unicast DNS before mDNS. On networks where the upstream resolver answers `.local` queries (router cache, another Bonjour responder, OS-level helpers), this returns a confidently wrong address. For names ending in `.local` we now skip unicast and go straight to ESP-IDF's `mdns_query_a` with a 2 s timeout.

7. **Stream JSON chunks with brace-depth tracking instead of accumulating** — Large `$File/SendJSON` responses arrive split across line-terminated TCP chunks. The previous `std::string` accumulator fragmented the heap on each grow/free cycle for big documents. New path feeds chunks straight into the JSON parser and tracks outer-brace depth (string-/escape-aware so `{` inside a macro action like `G92 Z{z}` doesn't count) to know when a document is complete and when the parser is safe to reset. Continuation chunks route through `handle_other` → `handle_json` based on `json_in_progress()`, not just `line[0] == '{'`.

8. **Advance macro chain when FluidNC returns bare error:N** — FluidNC's Telnet path can emit a bare `error:N` (no JSON wrapper) on missing files, which never fires `endDocument` and leaves the listener chain stalled on "Reading Macros" forever. New `file_request_failed_advance()` hook in `show_error()` advances the chain via `s_pending_file_listener`. Guards against double-advance when FluidNC emits both a wrapped JSON status AND a bare `error:N` for the same request: a 250 ms cooldown timestamp and a `json_in_progress()` check together suppress stray errors arriving right after a chain transition.

9. **Add FNC_RX_TRACE diagnostic logging for the FluidNC link** — Single `#define` in `Config.h` (default OFF, zero runtime cost when disabled) that surfaces RX events via `dbg_printf`: `[rx-err]`, `[rx-ok]`, `[rx-other]`, `[json] len=N d=<depth> | <peek>`, `[macro-chain] ...`, `[prefs] L<level> key=<key>`. Made debugging the next set of issues possible without a wireshark.

10. **Stop dropping RX bytes by bounding tcp_refill_rx + draining N per loop** — The actual root cause of "stuck on Reading Macros" over WiFi. `wifi_poll()` could refill the RX ring buffer with several KB per call (loops `recv()` until kernel buffer empty) while `fnc_poll()` drained exactly one byte per loop iteration. A 5 KB preferences.json burst overran the 2 KB ring and silently dropped bytes via `rx_push`'s overflow guard, leaving the streaming parser to see a truncated key like `"wfee,"` instead of `"wfeedrate"`, lose sync, and never finish the document. Two fixes in tandem: cap `tcp_refill_rx()` recv to available ring space (TCP flow control then pauses FluidNC if we fall behind), and drain 64 bytes per loop tick. All previous chain-advance / depth-tracking / mDNS fixes were working around symptoms of this.

## Impact on UART builds

Most changes are positive for UART too, not just WiFi:
- Redraw coalescing — less flicker, less heap churn, faster UI response on UART.
- Boot handshake + link recovery — pendant connects reliably on first boot and auto-recovers from transient UART hiccups instead of needing a power-cycle dance.
- Cmd-macro execution — `type:"CMD"` macros now run on UART builds where they previously silently failed.
- 64-byte drain per loop tick — UART at 1 Mbaud (CYD/PiBot baud) no longer falls behind on long bursts (SD file lists, status during heavy jogging).

The WiFi-specific commits (5, 6, 10) leave UART code paths untouched. JSON depth tracking and stale-error suppression (7, 8) are no-ops on UART because its `[MSG:JSON:...]` wrapping delivers each chunk as a complete document.

## Out of scope

My fork's default branch ([`pmokbel/FluidDial`](https://github.com/pmokbel/FluidDial)) also contains hardware support for the PiBot Pendant V4 — a custom CYD-based board with FT5x06 capacitive touch on I2C1, button/encoder pin remap, and display invert. Pin/config taken from the [Lumen-Works-Engineering/FluidDial](https://github.com/Lumen-Works-Engineering/FluidDial) fork. That's a hardware-specific change and not appropriate for this general-purpose PR — happy to open a separate PR for PiBot support if you'd like to bring it in.

## Test plan

- [x] Builds clean: `pio run -e pibot && pio run -e cyddial && pio run -e m5dial`
- [x] Macros load over WiFi from preferences.json (multi-statement `cmd:` actions split correctly)
- [x] Macros load over UART at 1 Mbaud
- [x] Boot handshake reconnects across power-cycle of either pendant or FluidNC
- [x] WiFi captive-portal setup unchanged (FirstBootScene + WiFiSetupScene work end-to-end)
- [x] Display does not flicker during status streaming on either transport
- [x] mDNS `.local` resolution prefers mDNS over unicast (verified against a router that hijacks unicast `.local`)
