### PR TITLE
Add PiBot Pendant V4 hardware support (gated behind -DPIBOT_PENDANT)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ src/version.*
 junk
 release
 .DS_Store
+platformio.local.ini

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,7 @@
 
 [platformio]
 default_envs = m5dial, cyddial
+extra_configs = platformio.local.ini
 
 [common]
 build_flags =
@@ -22,6 +23,13 @@ lib_deps =
     https://github.com/MitchBradley/json-streaming-parser#charp-1.0.2
     https://github.com/MitchBradley/GrblParser#9108f54
 build_src_filter = +<*.c> +<*.h> +<*.cpp> +<*.hpp>  -<System*.cpp> -<Hardware*.cpp> +<System.cpp> +<SystemScene.cpp> -<Touch_Class.cpp>
+
+; Per-developer overrides (upload port, WiFi creds, OTA flags, etc.) live in
+; platformio.local.ini (gitignored). The section below provides empty
+; defaults so the build works without that file.
+[pibot_local] 
+build_flags =
+
 
 [env:m5dial]
 ; Pendant based on M5Dial
@@ -173,3 +181,15 @@ build_flags = -O0 -xc++ -std=c++17 -lSDL2
   -I"/usr/local/include/SDL2"                  ; x86_64 Mac (Intel)
   -L"/usr/local/lib"
 build_src_filter = ${common.build_src_filter} +<SystemMacOS_CYD.cpp> -<Encoder.cpp> +<Touch_Class.cpp>
+
+[env:pibot]
+; Per-developer build/upload settings (upload_port, upload_speed, etc.)
+; live in platformio.local.ini.
+extends = env:cyd_base
+build_flags =
+    ${env:cyd_base.build_flags}
+    -DCAPACITIVE_CYD
+    -DCYD_BUTTONS
+    -DPIBOT_PENDANT
+    -DFNC_BAUD=1000000
+    ${pibot_local.build_flags}

--- a/src/Hardware2432.cpp
+++ b/src/Hardware2432.cpp
@@ -28,7 +28,12 @@
 // CYD that is supposed to control battery charging, cutting the
 // traces that connect it to the battery circuit and running a wire
 // over to the photoresistor.
+#ifdef PIBOT_PENDANT
+// PiBot uses GPIO 34 for the band switch, not a lockout input.
+int lockout_pin = -1;
+#else
 int lockout_pin = GPIO_NUM_34;
+#endif
 
 m5::Touch_Class  xtouch;
 m5::Touch_Class& touch = xtouch;
@@ -125,6 +130,9 @@ static void init_panel_st7789() {
     cfg.pin_cs          = GPIO_NUM_15;
     cfg.offset_rotation = base_rotation;
     cfg.bus_shared      = false;
+#ifdef PIBOT_PENDANT
+    cfg.invert = true;
+#endif
     p.config(cfg);
 
     p.light(&light);
@@ -142,6 +150,9 @@ static void init_panel_ili9341() {
     cfg.pin_cs          = GPIO_NUM_15;
     cfg.offset_rotation = base_rotation;
     cfg.bus_shared      = false;
+#ifdef PIBOT_PENDANT
+    cfg.invert = true;
+#endif
     p.config(cfg);
 
     p.light(&light);
@@ -160,10 +171,33 @@ int green_button_pin = -1;
 int enc_a, enc_b;
 
 #ifdef CAPACITIVE_CYD
+#    ifdef PIBOT_PENDANT
+lgfx::Touch_FT5x06 _touch_ft5x06;
+#    else
 lgfx::Touch_CST816S _touch_cst816s;
+#    endif
 
 void init_capacitive_cyd() {
     {
+#    ifdef PIBOT_PENDANT
+        // PiBot Pendant V4: FT5x06 capacitive touch on I2C bus 1.
+        auto cfg            = _touch_ft5x06.config();
+        cfg.i2c_port        = I2C_NUM_1;
+        cfg.pin_sda         = GPIO_NUM_32;
+        cfg.pin_scl         = GPIO_NUM_25;
+        cfg.pin_int         = GPIO_NUM_36;
+        cfg.pin_rst         = -1;
+        cfg.offset_rotation = base_rotation;
+        cfg.freq            = 400000;
+        cfg.x_min           = 0;
+        cfg.x_max           = 239;
+        cfg.y_min           = 0;
+        cfg.y_max           = 319;
+        cfg.bus_shared      = false;
+        _touch_ft5x06.config(cfg);
+        display.getPanel()->setTouch(&_touch_ft5x06);
+        display.getPanel()->initTouch();
+#    else
         auto cfg            = _touch_cst816s.config();
         cfg.i2c_port        = I2C_NUM_0;
         cfg.pin_sda         = GPIO_NUM_33;
@@ -177,12 +211,24 @@ void init_capacitive_cyd() {
         _touch_cst816s.config(cfg);
         display.getPanel()->setTouch(&_touch_cst816s);
         display.getPanel()->initTouch();
+#    endif
     }
     setBacklightPin(GPIO_NUM_27);
 
     pinMode(lockout_pin, INPUT);
 
-#    ifdef CYD_BUTTONS
+#    ifdef PIBOT_PENDANT
+    // PiBot Pendant V4 wiring: encoder B on GPIO 27, and the dial/green
+    // RGB-LED pins are swapped vs the stock CYD button layout.
+    enc_a            = GPIO_NUM_22;
+    enc_b            = GPIO_NUM_27;
+    red_button_pin   = GPIO_NUM_4;   // RGB LED Red
+    dial_button_pin  = GPIO_NUM_16;  // RGB LED Green (PiBot dial)
+    green_button_pin = GPIO_NUM_17;  // RGB LED Blue  (PiBot green)
+    pinMode(red_button_pin, INPUT_PULLUP);
+    pinMode(dial_button_pin, INPUT_PULLUP);
+    pinMode(green_button_pin, INPUT_PULLUP);
+#    elif defined(CYD_BUTTONS)
     enc_a = GPIO_NUM_22;
     enc_b = GPIO_NUM_21;
     // rotary_button_pin = GPIO_NUM_35;

--- a/src/Hardware2432.hpp
+++ b/src/Hardware2432.hpp
@@ -1,4 +1,13 @@
-#ifdef DEBUG_TO_USB
+#ifdef PIBOT_PENDANT
+
+// PiBot Pendant V4 routes the FluidNC UART through UART0 on
+// GPIO 1/3. Backlight stays on GPIO 21 (set via setBacklightPin).
+
+constexpr static const int PND_RX_FNC_TX_PIN = GPIO_NUM_1;
+constexpr static const int PND_TX_FNC_RX_PIN = GPIO_NUM_3;
+constexpr static const int FNC_UART_NUM      = 0;
+
+#elif defined(DEBUG_TO_USB)
 
 // This variant lets you have debugging output on the
 // USB serial port, at the expense of not being able


### PR DESCRIPTION
## Summary

Adds hardware support for the **PiBot Pendant V4** — a custom CYD-based pendant with FT5x06 capacitive touch, swapped dial/green RGB-LED button pins, encoder B on GPIO 27, and panel-invert. All differences from the stock CYD are gated behind the `-DPIBOT_PENDANT` build flag so existing builds (`m5dial`, `cyddial`, `cyd_*`) are unaffected — only a new `pio run -e pibot` environment opts in.

## What it changes

- **`src/Hardware2432.hpp`** — adds a `PIBOT_PENDANT` branch that routes the FluidNC link through UART0 on GPIO 1/3 (PiBot wires its FNC connector to those pins instead of the DEBUG_TO_USB GPIO 21/35 variant).
- **`src/Hardware2432.cpp`** — wraps five existing code regions in `#ifdef PIBOT_PENDANT … #else … #endif`:
  - `lockout_pin = -1` (PiBot uses GPIO 34 for a future band-switch input, not for the photoresistor lockout).
  - `cfg.invert = true` on both `Panel_ST7789` and `Panel_ILI9341` configs.
  - Touch driver: `Touch_FT5x06` on `I2C_NUM_1` (SDA=GPIO 32, SCL=GPIO 25, INT=GPIO 36) instead of the stock `Touch_CST816S` on I2C_NUM_0.
  - Encoder B on GPIO 27, encoder A unchanged on GPIO 22.
  - Dial/green RGB-LED button pin swap (PiBot dial=GPIO 16, green=GPIO 17; stock CYD dial=17, green=16).
- **`platformio.ini`** — adds `[env:pibot]` extending `[env:cyd_base]` with `-DPIBOT_PENDANT -DCYD_BUTTONS -DCAPACITIVE_CYD -DFNC_BAUD=1000000`. Reads developer-specific upload settings from a gitignored `platformio.local.ini` via `extra_configs`.
- **`.gitignore`** — excludes `platformio.local.ini`.

Total diff: 4 files, ~80 lines added, ~3 modified.

## What it intentionally does NOT include

Band switch (GPIO 34/35/39) and potentiometer (GPIO 33) integration into the jog UI are **not** in this PR. The PiBot V4 board has these inputs wired, but using them requires non-trivial changes to `MultiJogScene` that I'd rather propose separately when they're stable. The pins are just left unconfigured — selecting the `pibot` environment today gives you a working pendant with display, touch, encoder, buttons, and either UART or WiFi/Telnet (from #50). Band switch / pot are reserved for a follow-up.

## Attribution

Pins and hardware configuration for the PiBot Pendant V4 were originally figured out by [Lumen-Works-Engineering/FluidDial](https://github.com/Lumen-Works-Engineering/FluidDial). This PR ports the minimum needed for a working pendant; the more elaborate jog UX from that fork is not included here.

## Test plan

- [x] Builds clean: `pio run -e pibot && pio run -e cyddial && pio run -e m5dial`
- [x] Display lights up with correct orientation/color (no inversion artifacts) on PiBot V4 hardware
- [x] Touch input works (FT5x06 responds on I2C1)
- [x] Encoder turns smoothly in both directions
- [x] Red / dial / green buttons each trigger their respective actions (verifies the dial/green pin swap)
- [x] UART link to FluidNC over GPIO 1/3 works at 1 Mbaud
- [x] Stock CYD builds still work (no regressions for non-PiBot users)
