### PR TITLE
Fix CYD encoder skipping via interrupt-driven decoding and add battery indicator for CYD

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In WiFi mode the pendant communicates with FluidNC over WebSockets on your local
 - **SD File** — browse and run G-code files directly from the FluidNC SD card
 - **Macros** — store and execute custom G-code macros from the pendant
 - **Captive portal setup** — configure WiFi credentials directly from your phone or browser
-- **Battery indicator** *(experimental, M5Dial only)* — battery level shown in the status bar when running on battery power
+- **Battery indicator** *(experimental)* — Supported in both M5Dial and CYD versions. *See [this sample project for CYD battery operation](https://github.com/figamore/FigDial)*
 
 ---
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -70,6 +70,7 @@ build_flags =
     ${common.build_flags}
     -DUSE_LOVYANGFX
     -DUSE_WIFI
+    -DCYD_BATTERY_ADC
     ;-DCORE_DEBUG_LEVEL=5
     -DCYD_BUTTONS
 custom_filesystem_start=0x290000

--- a/src/DisplaySettingsScene.h
+++ b/src/DisplaySettingsScene.h
@@ -6,7 +6,7 @@
 
 class DisplaySettingsScene : public Scene {
 public:
-    DisplaySettingsScene() : Scene("Display") {}
+    DisplaySettingsScene() : Scene("Display", 4) {}
 
     void onEntry(void* arg = nullptr) override;
     void onEncoder(int delta) override;

--- a/src/Drawing.cpp
+++ b/src/Drawing.cpp
@@ -339,8 +339,9 @@ void drawWiFiSignalBars(int x0, int y_bot) {
         canvas.fillRect(x0 + i * (W + GAP), y_bot - H[i], W, H[i], color);
     }
 }
+#endif
 
-#ifdef USE_M5
+#if defined(USE_M5) || defined(USE_LOVYANGFX)
 void drawBatteryLevel(int x0, int y_bot) {
     int level = battery_level();
     if (level < 0) return;
@@ -351,7 +352,7 @@ void drawBatteryLevel(int x0, int y_bot) {
     constexpr int NH = 7;
 
     bool charging  = battery_charging();
-    int  fill_color = charging ? ORANGE : (level > 50) ? GREEN : (level > 20) ? YELLOW : RED;
+    int  fill_color = charging ? BLACK : (level > 50) ? GREEN : (level > 20) ? YELLOW : RED;
 
     // Body outline and nub
     canvas.drawRect(x0, y_bot - H, W, H, WHITE);
@@ -367,12 +368,22 @@ void drawBatteryLevel(int x0, int y_bot) {
     if (charging) {
         int bx = x0 + W / 2;
         int by = y_bot - (H + 1) / 2;  // vertical center
-        canvas.fillTriangle(bx + 3, by - 4, bx - 1, by, bx + 3, by, WHITE);
-        canvas.fillTriangle(bx - 3, by, bx + 1, by, bx - 3, by + 4, WHITE);
+        canvas.fillTriangle(bx + 3, by - 4, bx - 1, by, bx + 3, by, GREEN);
+        canvas.fillTriangle(bx - 3, by, bx + 1, by, bx - 3, by + 4, GREEN);
     }
 }
 #endif
 
+#if defined(USE_M5) || defined(USE_LOVYANGFX)
+static void drawBatteryLevelOverlay() {
+    if (round_display) return;   // M5 Dial: battery indicator only shown in menu scene
+    int level = battery_level();
+    if (level < 0) return;
+    drawBatteryLevel(display_short_side() - 29, 20);
+}
+#endif
+
+#ifdef USE_WIFI
 static void drawWiFiSignalOverlay() {
     if (round_display) return;   // M5 Dial: WiFi indicator only shown in menu scene
     drawWiFiSignalBars(5, 20);
@@ -382,6 +393,9 @@ static void drawWiFiSignalOverlay() {
 void refreshDisplay() {
 #ifdef USE_WIFI
     drawWiFiSignalOverlay();
+#endif
+#if defined(USE_M5) || defined(USE_LOVYANGFX)
+    drawBatteryLevelOverlay();
 #endif
     display.startWrite();
     canvas.pushSprite(sprite_offset.x, sprite_offset.y);

--- a/src/Drawing.h
+++ b/src/Drawing.h
@@ -91,7 +91,7 @@ void drawPngBackground(const char* filename);
 void drawWiFiSignalBars(int x0, int y_bot);
 #endif
 
-#ifdef USE_M5
+#if defined(USE_M5) || defined(USE_LOVYANGFX)
 void drawBatteryLevel(int x0, int y_bot);
 #endif
 

--- a/src/Encoder.cpp
+++ b/src/Encoder.cpp
@@ -12,23 +12,26 @@
 
 namespace {
 #ifdef USE_LOVYANGFX
-constexpr int8_t quadrature_lut[16] = {
+static const DRAM_ATTR int8_t quadrature_lut[16] = {
     0, -1, 1, 0,
     1, 0, 0, -1,
     -1, 0, 0, 1,
     0, 1, -1, 0,
 };
 
-int     encoder_a_pin    = -1;
-int     encoder_b_pin    = -1;
-int16_t encoder_count    = 0;
-uint8_t encoder_state    = 0;
+static int              encoder_a_pin = -1;
+static int              encoder_b_pin = -1;
+static volatile int32_t encoder_count = 0;
+static volatile uint8_t encoder_state = 0;
 
-uint8_t read_encoder_state() {
-    if (encoder_a_pin < 0 || encoder_b_pin < 0) {
-        return 0;
-    }
+static uint8_t IRAM_ATTR read_encoder_state_isr() {
     return (digitalRead(encoder_a_pin) << 1) | digitalRead(encoder_b_pin);
+}
+
+static void IRAM_ATTR encoder_isr() {
+    uint8_t next_state = read_encoder_state_isr();
+    encoder_count += quadrature_lut[(encoder_state << 2) | next_state];
+    encoder_state = next_state;
 }
 #else
 bool pcnt_ready = false;
@@ -98,13 +101,13 @@ void init_encoder(int a_pin, int b_pin) {
     pinMode(encoder_b_pin, INPUT_PULLUP);
 
     encoder_count = 0;
-    encoder_state = read_encoder_state();
+    encoder_state = read_encoder_state_isr();
+
+    attachInterrupt(digitalPinToInterrupt(encoder_a_pin), encoder_isr, CHANGE);
+    attachInterrupt(digitalPinToInterrupt(encoder_b_pin), encoder_isr, CHANGE);
 }
 
 int16_t get_encoder() {
-    uint8_t next_state = read_encoder_state();
-    encoder_count += quadrature_lut[(encoder_state << 2) | next_state];
-    encoder_state = next_state;
-    return encoder_count;
+    return (int16_t)encoder_count;
 }
 #endif

--- a/src/Hardware2432.cpp
+++ b/src/Hardware2432.cpp
@@ -30,6 +30,18 @@
 // over to the photoresistor.
 int lockout_pin = GPIO_NUM_34;
 
+#ifdef CYD_BATTERY_ADC
+#    ifndef CYD_BATTERY_ADC_PIN
+#        define CYD_BATTERY_ADC_PIN GPIO_NUM_39
+#    endif
+#    ifndef CYD_BATTERY_ADC_MULTIPLIER_NUM
+#        define CYD_BATTERY_ADC_MULTIPLIER_NUM 1534
+#    endif
+#    ifndef CYD_BATTERY_ADC_MULTIPLIER_DEN
+#        define CYD_BATTERY_ADC_MULTIPLIER_DEN 1000
+#    endif
+#endif
+
 m5::Touch_Class  xtouch;
 m5::Touch_Class& touch = xtouch;
 
@@ -180,7 +192,11 @@ void init_capacitive_cyd() {
     }
     setBacklightPin(GPIO_NUM_27);
 
+#ifdef CYD_BATTERY_ADC
+    analogSetPinAttenuation(CYD_BATTERY_ADC_PIN, ADC_11db);
+#else
     pinMode(lockout_pin, INPUT);
+#endif
 
 #    ifdef CYD_BUTTONS
     enc_a = GPIO_NUM_22;
@@ -539,6 +555,10 @@ bool    touch_debounce = false;
 int32_t touch_timeout  = 0;
 
 bool ui_locked(bool redrawButtonsFlag) {
+#ifdef CYD_BATTERY_ADC
+    (void)redrawButtonsFlag;
+    return false;
+#else
     bool locked = digitalRead(lockout_pin);
     if ((int)locked != last_locked) {
         last_locked = locked;
@@ -547,6 +567,7 @@ bool ui_locked(bool redrawButtonsFlag) {
         }
     }
     return locked;
+#endif
 }
 
 bool in_rect(Point test, Point xy, Point wh) {
@@ -588,5 +609,105 @@ void update_events() {
 }
 
 void ackBeep() {}
+
+int adc_millivolts(int pin) {
+    return analogReadMilliVolts(pin);
+}
+
+int battery_adc_millivolts() {
+#ifndef CYD_BATTERY_ADC
+    return -1;
+#else
+    return adc_millivolts(CYD_BATTERY_ADC_PIN);
+#endif
+}
+
+int battery_millivolts() {
+#ifndef CYD_BATTERY_ADC
+    return -1;
+#else
+    return (battery_adc_millivolts() * CYD_BATTERY_ADC_MULTIPLIER_NUM) / CYD_BATTERY_ADC_MULTIPLIER_DEN;
+#endif
+}
+
+int battery_level() {
+#ifndef CYD_BATTERY_ADC
+    return -1;
+#else
+    static int      cached_level  = -1;
+    static int      smoothed_mv   = -1;
+    static uint32_t next_read_ms  = 0;
+
+#    if defined(RESISTIVE_CYD) && defined(CAPACITIVE_CYD)
+    if (display_num == 1) {
+        return -1;
+    }
+#    endif
+
+    uint32_t now = millis();
+    if (now < next_read_ms) {
+        return cached_level;
+    }
+    next_read_ms = now + 1000;
+
+    int millivolts = battery_millivolts();
+    if (millivolts < 3000 || millivolts > 4400) {
+        cached_level = -1;
+        return cached_level;
+    }
+
+    // Exponential moving average (alpha=0.25)
+    smoothed_mv = (smoothed_mv < 3000) ? millivolts : (smoothed_mv * 3 + millivolts) / 4;
+    millivolts  = smoothed_mv;
+
+    struct LevelPoint {
+        int mv;
+        int pct;
+    };
+    static constexpr LevelPoint curve[] = {
+        { 4200, 100 },
+        { 4100, 90 },
+        { 4000, 80 },
+        { 3930, 70 },
+        { 3860, 60 },
+        { 3800, 50 },
+        { 3750, 40 },
+        { 3700, 30 },
+        { 3650, 20 },
+        { 3550, 10 },
+        { 3300, 0 },
+    };
+
+    if (millivolts >= curve[0].mv) {
+        cached_level = 100;
+        return cached_level;
+    }
+    for (size_t i = 1; i < sizeof(curve) / sizeof(curve[0]); ++i) {
+        if (millivolts >= curve[i].mv) {
+            int high_mv  = curve[i - 1].mv;
+            int low_mv   = curve[i].mv;
+            int high_pct = curve[i - 1].pct;
+            int low_pct  = curve[i].pct;
+            cached_level = low_pct + ((millivolts - low_mv) * (high_pct - low_pct)) / (high_mv - low_mv);
+            return cached_level;
+        }
+    }
+
+    cached_level = 0;
+    return cached_level;
+#endif
+}
+
+bool battery_charging() {
+#ifndef CYD_BATTERY_ADC
+    return false;
+#else
+    static int cached = -1;
+    if (cached < 0) {
+        cached = (battery_millivolts() > 4250) ? 1 : 0;
+    }
+    return cached == 1;
+#endif
+}
 
 void deep_sleep(int us) {}

--- a/src/System.h
+++ b/src/System.h
@@ -47,6 +47,11 @@ static inline uint32_t millis() { return m5gfx::millis(); }
 
 int  battery_level();    // Returns 0-100, or -1 if no battery
 bool battery_charging(); // Returns true while charging via USB
+#ifdef USE_LOVYANGFX
+int adc_millivolts(int pin);
+int battery_adc_millivolts();
+int battery_millivolts();
+#endif
 
 extern LGFX_Device&     display;
 extern LGFX_Sprite      canvas;

--- a/src/SystemMacOS_CYD.cpp
+++ b/src/SystemMacOS_CYD.cpp
@@ -330,8 +330,11 @@ nvs_handle_t nvs_init(const char* name) {
     return strdup(dname);
 }
 
-int  battery_level()    { return 75; }
-bool battery_charging() { return true; }
+int  battery_level()           { return 75; }
+bool battery_charging()        { return true; }
+int  adc_millivolts(int pin)   { return (pin == 39) ? 2484 : 0; }
+int  battery_adc_millivolts()  { return adc_millivolts(39); }
+int  battery_millivolts()      { return 3810; }
 
 #ifdef USE_WIFI
 static WiFiConfig _preview_cfg = { "FluidNC", "", "192.168.0.1", true };

--- a/src/SystemScene.cpp
+++ b/src/SystemScene.cpp
@@ -121,6 +121,17 @@ void SystemScene::reDisplay() {
         }
     }
 
+#if defined(USE_LOVYANGFX) && defined(CYD_BATTERY_ADC)
+    if (!round_display) {
+        int mv = battery_millivolts();
+        if (mv > 0) {
+            char buf[32];
+            snprintf(buf, sizeof(buf), "Battery: %d.%02d V", mv / 1000, (mv % 1000) / 10);
+            centered_text(buf, 210, LIGHTGREY, TINY);
+        }
+    }
+#endif
+
     drawButtonLegends("Back", "Select", "");
     refreshDisplay();
 }

--- a/src/SystemScene.h
+++ b/src/SystemScene.h
@@ -8,7 +8,7 @@ class SystemScene : public Scene {
     int _selected = 0;
 
 public:
-    SystemScene() : Scene("System") {}
+    SystemScene() : Scene("System", 4) {}
 
     void onEntry(void* arg = nullptr) override;
     void onEncoder(int delta) override;


### PR DESCRIPTION
### CYD Battery Indicator
  A battery voltage indicator is now displayed in the System scene for CYD builds.

  ### Encoder Responsiveness Fix (CYD)
  Navigating menus with a rotary encoder or CNC handwheel on CYD is now smoother and more reliable. Two issues were resolved:
  - **Too much sensitivity**: `SystemScene` and `DisplaySettingsScene` were missing the `encoder_scale = 4` used by all other navigation scenes,
causing each physical detent to trigger 4 selection changes instead of 1.
  - **Skipped steps**: The encoder was polled in the main loop, so transitions occurring during display redraws were silently
  dropped. The CYD encoder path is now interrupt driven.