### PR TITLE
Physical button debouncing, reintroduce brightness control for CYD, and restore UI lockout

### DIFF
--- a/src/BrightnessScene.cpp
+++ b/src/BrightnessScene.cpp
@@ -1,28 +1,29 @@
 // 2026 - Figamore
 
-#ifdef USE_M5
-
 #include "BrightnessScene.h"
 #include "Drawing.h"
 #include "System.h"
 #include "SystemScene.h"
 
-static constexpr int MIN_BRIGHTNESS = 8;
+static constexpr int MIN_BRIGHTNESS_PCT = 3;  // ~8/255
 
 void BrightnessScene::onEntry(void* arg) {
     if (initPrefs()) {
         getPref("brightness", &_brightness);
+        _brightness = std::min(100, std::max(MIN_BRIGHTNESS_PCT, _brightness));
     }
     reDisplay();
 }
 
 void BrightnessScene::onEncoder(int delta) {
-    if (delta > 0 && _brightness < 255) {
-        display.setBrightness(++_brightness);
+    if (delta > 0 && _brightness < 100) {
+        _brightness = std::min(100, _brightness + 1);
+        display.setBrightness(getBrightness());
         setPref("brightness", _brightness);
     }
-    if (delta < 0 && _brightness > MIN_BRIGHTNESS) {
-        display.setBrightness(--_brightness);
+    if (delta < 0 && _brightness > MIN_BRIGHTNESS_PCT) {
+        _brightness = std::max(MIN_BRIGHTNESS_PCT, _brightness - 1);
+        display.setBrightness(getBrightness());
         setPref("brightness", _brightness);
     }
     reDisplay();
@@ -36,9 +37,8 @@ void BrightnessScene::reDisplay() {
     centered_text("Brightness", 40, WHITE, SMALL);
     drawRect(45, 52, 150, 1, 0, DARKGREY);
 
-    int  pct = (_brightness * 100) / 255;
     char buf[8];
-    snprintf(buf, sizeof(buf), "%d%%", pct);
+    snprintf(buf, sizeof(buf), "%d%%", _brightness);
     centered_text(buf, 100, WHITE, SMALL);
 
     centered_text("Turn dial to adjust", 140, LIGHTGREY, TINY);
@@ -50,10 +50,9 @@ void BrightnessScene::reDisplay() {
 int BrightnessScene::getBrightness() {
     if (initPrefs()) {
         getPref("brightness", &_brightness);
+        _brightness = std::min(100, std::max(MIN_BRIGHTNESS_PCT, _brightness));
     }
-    return _brightness;
+    return (_brightness * 255) / 100;
 }
 
 BrightnessScene brightnessScene;
-
-#endif  // USE_M5

--- a/src/BrightnessScene.h
+++ b/src/BrightnessScene.h
@@ -1,14 +1,12 @@
 #pragma once
 
-#ifdef USE_M5
-
 #include "Scene.h"
 
 class BrightnessScene : public Scene {
-    int _brightness = 255;
+    int _brightness = 100;  // stored as percentage 0-100
 
 public:
-    BrightnessScene() : Scene("Brightness") {}
+    BrightnessScene() : Scene("Brightness", 4) {}
 
     void onEntry(void* arg = nullptr) override;
     void onEncoder(int delta) override;
@@ -19,5 +17,3 @@ public:
 };
 
 extern BrightnessScene brightnessScene;
-
-#endif  // USE_M5

--- a/src/Hardware2432.cpp
+++ b/src/Hardware2432.cpp
@@ -194,9 +194,8 @@ void init_capacitive_cyd() {
 
 #ifdef CYD_BATTERY_ADC
     analogSetPinAttenuation(CYD_BATTERY_ADC_PIN, ADC_11db);
-#else
-    pinMode(lockout_pin, INPUT);
 #endif
+    pinMode(lockout_pin, INPUT);
 
 #    ifdef CYD_BUTTONS
     enc_a = GPIO_NUM_22;
@@ -560,10 +559,6 @@ bool    touch_debounce = false;
 int32_t touch_timeout  = 0;
 
 bool ui_locked(bool redrawButtonsFlag) {
-#ifdef CYD_BATTERY_ADC
-    (void)redrawButtonsFlag;
-    return false;
-#else
     bool locked = digitalRead(lockout_pin);
     if ((int)locked != last_locked) {
         last_locked = locked;
@@ -572,7 +567,6 @@ bool ui_locked(bool redrawButtonsFlag) {
         }
     }
     return locked;
-#endif
 }
 
 bool in_rect(Point test, Point xy, Point wh) {
@@ -657,7 +651,6 @@ int battery_level() {
 
     int millivolts = battery_millivolts();
     if (millivolts < 3000 || millivolts > 4400) {
-        cached_level = -1;
         return cached_level;
     }
 

--- a/src/Hardware2432.cpp
+++ b/src/Hardware2432.cpp
@@ -506,35 +506,46 @@ void system_background() {
     drawBackground(BLACK);
 }
 
+static constexpr int32_t BUTTON_DEBOUNCE_MS = 50;
+
 bool switch_button_touched(bool& pressed, int& button) {
-    static int last_red   = -1;
-    static int last_green = -1;
-    static int last_dial  = -1;
-    bool       state;
+    static int     last_red    = -1;
+    static int     last_green  = -1;
+    static int     last_dial   = -1;
+    static int32_t expire_red   = 0;
+    static int32_t expire_dial  = 0;
+    static int32_t expire_green = 0;
+
+    int32_t now = (int32_t)milliseconds();
+    bool    state;
+
     if (red_button_pin != -1) {
         state = digitalRead(red_button_pin);
-        if ((int)state != last_red) {
-            last_red = state;
-            button   = 0;
-            pressed  = !state;
+        if ((int)state != last_red && (now - expire_red) >= 0) {
+            last_red   = state;
+            expire_red = now + BUTTON_DEBOUNCE_MS;
+            button     = 0;
+            pressed    = !state;
             return true;
         }
     }
     if (dial_button_pin != -1) {
         state = digitalRead(dial_button_pin);
-        if ((int)state != last_dial) {
-            last_dial = state;
-            button    = 1;
-            pressed   = !state;
+        if ((int)state != last_dial && (now - expire_dial) >= 0) {
+            last_dial   = state;
+            expire_dial = now + BUTTON_DEBOUNCE_MS;
+            button      = 1;
+            pressed     = !state;
             return true;
         }
     }
     if (green_button_pin != -1) {
         state = digitalRead(green_button_pin);
-        if ((int)state != last_green) {
-            last_green = state;
-            button     = 2;
-            pressed    = !state;
+        if ((int)state != last_green && (now - expire_green) >= 0) {
+            last_green   = state;
+            expire_green = now + BUTTON_DEBOUNCE_MS;
+            button       = 2;
+            pressed      = !state;
             return true;
         }
     }
@@ -544,12 +555,6 @@ bool switch_button_touched(bool& pressed, int& button) {
 bool screen_encoder(int x, int y, int& delta) {
     return false;
 }
-
-struct button_debounce_t {
-    bool    debouncing;
-    bool    skipped;
-    int32_t timeout;
-} debounce[n_buttons] = { { false, false, 0 } };
 
 bool    touch_debounce = false;
 int32_t touch_timeout  = 0;

--- a/src/SystemScene.cpp
+++ b/src/SystemScene.cpp
@@ -17,12 +17,13 @@ struct SysItem {
 };
 
 static const SysItem items[] = {
-    { "Restart",  ""                  },
+    { "Restart",    ""                   },
 #ifdef USE_M5
-    { "Sleep",    "Press red to wake" },
-    { "Brightness", "Turn to adjust"  },
+    { "Sleep",      "Press red to wake"  },
+    { "Brightness", ""     },
 #else
-    { "Display",  "Adjust orientation" },
+    { "Display",    "Adjust orientation" },
+    { "Brightness", ""     },
 #endif
 };
 static const int N_ITEMS = (int)(sizeof(items) / sizeof(items[0]));
@@ -30,9 +31,9 @@ static const int N_ITEMS = (int)(sizeof(items) / sizeof(items[0]));
 static constexpr int ITEM_H_ROUND     = 48;
 static constexpr int ITEM_PITCH_ROUND = 48;
 static constexpr int ITEM_H_CYD       = 48;
-static constexpr int ITEM_PITCH_CYD   = 72;
+static constexpr int ITEM_PITCH_CYD   = 60;
 static constexpr int START_Y_ROUND    = 50;
-static constexpr int START_Y_CYD      = 60;
+static constexpr int START_Y_CYD      = 50;
 
 int SystemScene::itemCount() { return N_ITEMS; }
 
@@ -69,11 +70,9 @@ void SystemScene::activateSelected() {
             activate_scene(&displaySettingsScene);
 #endif
             break;
-#ifdef USE_M5
         case 2:
             activate_scene(&brightnessScene);
             break;
-#endif
     }
 }
 
@@ -125,9 +124,9 @@ void SystemScene::reDisplay() {
     if (!round_display) {
         int mv = battery_millivolts();
         if (mv > 0) {
-            char buf[32];
-            snprintf(buf, sizeof(buf), "Battery: %d.%02d V", mv / 1000, (mv % 1000) / 10);
-            centered_text(buf, 210, LIGHTGREY, TINY);
+            char buf[16];
+            snprintf(buf, sizeof(buf), "%d.%02d V", mv / 1000, (mv % 1000) / 10);
+            centered_text(buf, 36, DARKGREY, TINY);
         }
     }
 #endif

--- a/src/ardmain.cpp
+++ b/src/ardmain.cpp
@@ -5,7 +5,7 @@
 #include "FileParser.h"
 #include "Scene.h"
 #include "AboutScene.h"
-#ifdef USE_M5
+#if defined(USE_M5) || defined(USE_LOVYANGFX)
 #    include "BrightnessScene.h"
 #endif
 
@@ -46,7 +46,7 @@ void first_boot_complete() {
 void setup() {
     init_system();
 
-#ifdef USE_M5
+#if defined(USE_M5) || defined(USE_LOVYANGFX)
     display.setBrightness(brightnessScene.getBrightness());
 #else
     display.setBrightness(aboutScene.getBrightness());


### PR DESCRIPTION
## What's New

### Physical Button Debouncing
Mechanical button bounce on CYD physical buttons would cause single presses to register as multiple events. Each button now has its own debounce timer that ignores further state changes within 50 ms of a valid press or release.

### Brightness Control for CYD
The System scene now includes a Brightness option for CYD (this had been previously removed in v1.2.0. Brightness is stored as a percentage (3–100%) and adjusted in 1% increments per encoder detent. The saved value is now restored on boot.

### UI Lockout Restored
The lockout pin (GPIO 34) and the battery ADC pin (GPIO 39) were mistakenly treated as mutually exclusive during battery testing, which disabled the UI lockout feature for all CYD builds with battery monitoring enabled. Both features now operate independently on their respective pins.