### PR TITLE
Halt jogging when handwheel encoder stops rotating and fix resistive CYD physical pushbuttons.

### DIFF
--- a/src/DisplaySettingsScene.cpp
+++ b/src/DisplaySettingsScene.cpp
@@ -39,6 +39,11 @@ void DisplaySettingsScene::onRedButtonPress() {
     activate_scene(&systemScene);
 }
 
+void DisplaySettingsScene::onGreenButtonPress() {
+    next_layout(1);
+    reDisplay();
+}
+
 void DisplaySettingsScene::reDisplay() {
     background();
     drawMenuTitle("Display");
@@ -54,9 +59,9 @@ void DisplaySettingsScene::reDisplay() {
                            : "Unknown";
     centered_text(name, 100, WHITE, SMALL);
 
-    centered_text("Turn dial to rotate", 140, LIGHTGREY, TINY);
+    centered_text("Turn dial or press green", 140, LIGHTGREY, TINY);
 
-    drawButtonLegends("Back", "", "");
+    drawButtonLegends("Back", "Rotate", "");
     refreshDisplay();
 }
 

--- a/src/DisplaySettingsScene.h
+++ b/src/DisplaySettingsScene.h
@@ -12,6 +12,7 @@ public:
     void onEncoder(int delta) override;
     void onDialButtonPress() override;
     void onRedButtonPress() override;
+    void onGreenButtonPress() override;
     void reDisplay() override;
 };
 

--- a/src/Encoder.cpp
+++ b/src/Encoder.cpp
@@ -19,10 +19,11 @@ static const DRAM_ATTR int8_t quadrature_lut[16] = {
     0, 1, -1, 0,
 };
 
-static int              encoder_a_pin = -1;
-static int              encoder_b_pin = -1;
-static volatile int32_t encoder_count = 0;
-static volatile uint8_t encoder_state = 0;
+static int               encoder_a_pin         = -1;
+static int               encoder_b_pin         = -1;
+static volatile int32_t  encoder_count         = 0;
+static volatile uint8_t  encoder_state         = 0;
+static volatile uint32_t encoder_last_event_us = 0;
 
 static uint8_t IRAM_ATTR read_encoder_state_isr() {
     return (digitalRead(encoder_a_pin) << 1) | digitalRead(encoder_b_pin);
@@ -30,7 +31,11 @@ static uint8_t IRAM_ATTR read_encoder_state_isr() {
 
 static void IRAM_ATTR encoder_isr() {
     uint8_t next_state = read_encoder_state_isr();
-    encoder_count += quadrature_lut[(encoder_state << 2) | next_state];
+    int8_t  step       = quadrature_lut[(encoder_state << 2) | next_state];
+    if (step) {
+        encoder_count += step;
+        encoder_last_event_us = micros();
+    }
     encoder_state = next_state;
 }
 #else
@@ -92,6 +97,11 @@ int16_t get_encoder() {
     pcnt_get_counter_value(PCNT_UNIT_0, &count);
     return count;
 }
+
+uint32_t encoder_event_us() {
+    // PCNT has no per-pulse ISR; fall back to call time.
+    return micros();
+}
 #else
 void init_encoder(int a_pin, int b_pin) {
     encoder_a_pin = a_pin;
@@ -109,5 +119,9 @@ void init_encoder(int a_pin, int b_pin) {
 
 int16_t get_encoder() {
     return (int16_t)encoder_count;
+}
+
+uint32_t encoder_event_us() {
+    return encoder_last_event_us;
 }
 #endif

--- a/src/Encoder.h
+++ b/src/Encoder.h
@@ -2,5 +2,7 @@
 
 #include <cstdint>
 
-int16_t get_encoder();
-void    init_encoder(int a_pin, int b_pin);
+int16_t  get_encoder();
+void     init_encoder(int a_pin, int b_pin);
+
+uint32_t encoder_event_us();

--- a/src/Hardware2432.cpp
+++ b/src/Hardware2432.cpp
@@ -247,6 +247,9 @@ void init_resistive_cyd() {
     red_button_pin   = GPIO_NUM_4;   // RGB LED Red
     dial_button_pin  = GPIO_NUM_17;  // RGB LED Blue
     green_button_pin = GPIO_NUM_16;  // RGB LED Green
+    pinMode(red_button_pin, INPUT_PULLUP);
+    pinMode(dial_button_pin, INPUT_PULLUP);
+    pinMode(green_button_pin, INPUT_PULLUP);
 #    else
     red_button_pin = dial_button_pin = green_button_pin = -1;
 #    endif

--- a/src/MultiJogScene.cpp
+++ b/src/MultiJogScene.cpp
@@ -33,8 +33,10 @@ private:
     // MPG jog rate-limiting: accumulate encoder ticks and send at most one
     // jog command per MPG_INTERVAL_MS to avoid flooding FluidNC's planner queue.
     static const uint32_t MPG_INTERVAL_MS = 30;
-    int      _mpg_accum   = 0;
-    uint32_t _last_mpg_ms = 0;
+    static const uint32_t MPG_STOP_MS     = 280;
+    int      _mpg_accum      = 0;
+    uint32_t _last_mpg_ms    = 0;
+    uint32_t _last_mpg_tick_ms = 0;
 
 public:
     MultiJogScene() : Scene("Jog", 4, jog_help_text) {}
@@ -235,6 +237,9 @@ public:
             _continuous = false;
             _cancelling = true;
         }
+        _mpg_accum = 0;
+        _last_mpg_ms = 0;
+        _last_mpg_tick_ms = 0;
     }
     void next_axis() {
         int the_axis = the_selected_axis();
@@ -423,12 +428,12 @@ public:
         cancel_jog();
     }
 
-    void flush_mpg() {
+    void flush_mpg(bool force = false) {
         if (_mpg_accum == 0) {
             return;
         }
         uint32_t now = millis();
-        if ((now - _last_mpg_ms) >= MPG_INTERVAL_MS) {
+        if (force || (now - _last_mpg_ms) >= MPG_INTERVAL_MS) {
             start_mpg_jog(_mpg_accum);
             _mpg_accum   = 0;
             _last_mpg_ms = now;
@@ -437,11 +442,22 @@ public:
 
     void onEncoder(int delta) {
         _mpg_accum += delta;
+        _last_mpg_tick_ms = millis();
         flush_mpg();
     }
 
     void onPoll() override {
         flush_mpg();
+        if (state == Jog && !_continuous && _last_mpg_tick_ms != 0) {
+            uint32_t now = millis();
+            if ((now - _last_mpg_tick_ms) >= MPG_STOP_MS) {
+                flush_mpg(true);
+                if (_mpg_accum == 0) {
+                    cancel_jog();
+                    _last_mpg_tick_ms = 0;
+                }
+            }
+        }
     }
 
     void onDROChange() {

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -106,8 +106,10 @@ void dispatch_touch() {
             return;
         }
         int button;
-        if (screen_button_touched(t.state == m5::touch_state_t::touch, t.x, t.y, button)) {
-            if (t.state == m5::touch_state_t::touch) {
+       
+        bool btn_touching = (t.state & m5::touch_state_t::mask_touch) != 0;
+        if (screen_button_touched(btn_touching, t.x, t.y, button)) {
+            if (t.state == m5::touch_state_t::touch_begin) {
                 dispatch_button(true, button);
             } else if (t.state == m5::touch_state_t::none) {
                 dispatch_button(false, button);


### PR DESCRIPTION
# What's new

1. Handwheel idle stop — Handwheel now reliably stops jogging after rotation ceases.
1. Fix: resistive CYD buttons unresponsive in System scene. Missing INPUT_PULLUP on button GPIO pins and a touch debounce bug caused Select/Back to do nothing.
1. Display orientation: green button rotates layout
