### PR TITLE
Fix/pin espressif32 platform

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -34,7 +34,7 @@ build_flags =
 [env:m5dial]
 ; Pendant based on M5Dial
 ; http://wiki.fluidnc.com/en/hardware/official/M5Dial_Pendant
-platform = espressif32
+platform = espressif32@6.9.0    ; pin official platform (not the pioarduino fork, which also installs as "espressif32")
 board = m5stack-stamps3
 framework = arduino
 platform_packages =
@@ -58,7 +58,7 @@ build_src_filter = ${common.build_src_filter} +<SystemArduino.cpp> +<HardwareM5D
 [env:cyd_base]
 ; Pendant based on a 2432S028 "Cheap Yellow Display" and a hand wheel pulse encoder
 ; http://wiki.fluidnc.com/en/hardware/official/CYD_Dial_Pendant
-platform = espressif32
+platform = espressif32@6.9.0    ; pin official platform (not the pioarduino fork, which also installs as "espressif32")
 board = esp32dev
 framework = arduino
 platform_packages =

--- a/platformio.ini
+++ b/platformio.ini
@@ -92,7 +92,7 @@ build_flags =
     -DCYD_BUTTONS
     -DRESISTIVE_CYD
     -DCAPACITIVE_CYD
-    -DUSE_ESPNOW  ; uncomment to build with ESP-NOW transport (pending FluidNC upstream PR)
+    ; -DUSE_ESPNOW  ; uncomment to build with ESP-NOW transport (pending FluidNC upstream PR)
     ; -DDEV_SKIP_TO_SCENE=multiJogScene     ; uncomment to test different scenes
 
 # This is the original CYD build for a resistive CYD

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,7 @@ build_flags =
     -DWEBSOCKETS_TCP_TIMEOUT=750
 lib_deps =
     https://github.com/MitchBradley/json-streaming-parser#charp-1.0.2
-    https://github.com/MitchBradley/GrblParser#9108f54
+    https://github.com/MitchBradley/GrblParser#9108f54a3e30526b66194898676af34e96a87da9
 build_src_filter = +<*.c> +<*.h> +<*.cpp> +<*.hpp>  -<System*.cpp> -<Hardware*.cpp> +<System.cpp> +<SystemScene.cpp> -<Touch_Class.cpp>
 
 ; Per-developer overrides (upload port, WiFi creds, OTA flags, etc.) live in


### PR DESCRIPTION
Replace the short commit SHA with the full commit SHA and pin the espressif32 platform to the official PlatformIO release to prevent build errors in newer versions of PlatformIO.