### PR TITLE
Fix PiBot Pendant V4 touch by disabling FT5x06 interrupt on GPIO 36

### DIFF
--- a/src/Hardware2432.cpp
+++ b/src/Hardware2432.cpp
@@ -197,7 +197,7 @@ void init_capacitive_cyd() {
         cfg.i2c_port        = I2C_NUM_1;
         cfg.pin_sda         = GPIO_NUM_32;
         cfg.pin_scl         = GPIO_NUM_25;
-        cfg.pin_int         = GPIO_NUM_36;
+        cfg.pin_int         = -1;
         cfg.pin_rst         = -1;
         cfg.offset_rotation = base_rotation;
         cfg.freq            = 400000;


### PR DESCRIPTION
## Summary
Switch the PiBot Pendant V4 FT5x06 touch driver from interrupt-driven to polling mode on GPIO 36.

## Change
Set `cfg.pin_int = -1` in the `PIBOT_PENDANT` branch of `src/Hardware2432.cpp`. This disables the hardware interrupt and lets the driver poll the touch controller instead.

## Impact
- Scope: only affects `PIBOT_PENDANT` builds
- Side effects: minimal — the non-PiBot capacitive touch path already uses `pin_int = -1`, confirming polling is a reliable approach
- Benefit: more robust touch detection across varying conditions