### PR TITLE
Improve ESP-NOW pairing and reconnect strategy and make jogging more stable in Telnet mode

### DIFF
--- a/src/ESPNowMachineScene.cpp
+++ b/src/ESPNowMachineScene.cpp
@@ -14,6 +14,8 @@
 #include <string.h>
 #include <string>
 
+extern Scene menuScene;
+
 static constexpr int ITEM_H_ROUND     = 40;
 static constexpr int ITEM_PITCH_ROUND = 50;
 static constexpr int ITEM_H_CYD       = 34;
@@ -112,11 +114,7 @@ void ESPNowMachineScene::onEncoder(int delta) {
 void ESPNowMachineScene::activateSelected() {
     if (_selected < _profile_count) {
         if (espnow_select_profile((size_t)_selected)) {
-            if (parent_scene()) {
-                pop_scene();
-            } else {
-                activate_scene(&wifiSetupScene);
-            }
+            activate_at_top_level(&menuScene);
         } else {
             _profile_count = (int)espnow_profile_count();
             if (_selected >= itemCount()) {

--- a/src/FluidNCModel.cpp
+++ b/src/FluidNCModel.cpp
@@ -82,6 +82,7 @@ bool decode_state_string(const char* state_string, state_t& state) {
 void set_disconnected_state() {
     state           = Disconnected;
     my_state_string = "N/C";
+    jog_window_reset();
 }
 
 // clang-format off
@@ -174,7 +175,12 @@ void send_line(const char* s, int timeout) {
     dbg_println(s);
 }
 
-// Send a jog command over a networked transport without the per-line "ok" handshake.
+// Count of jog lines streamed over Telnet but not yet acked by "ok""" to prevent outrunning FluidNC planner.
+static int s_jog_window = 0;
+int        jog_window_outstanding() { return s_jog_window; }
+void       jog_window_reset() { s_jog_window = 0; }
+
+// Stream network jogs without blocking
 void send_jog_line(const char* s) {
 #ifdef USE_WIFI
     if (!wifi_use_uart_mode()) {  // WiFi / Telnet / ESP-NOW: stream, no ack-gate
@@ -183,29 +189,40 @@ void send_jog_line(const char* s) {
         }
         fnc_putchar('\n');
         dbg_println(s);
+        
+        if (jog_flow_control() == JogFlowControl::Window) {
+            ++s_jog_window;
+        }
         return;
     }
 #endif
     send_line(s);
 }
 
-static volatile int      s_jog_inflight     = 0;
-static uint32_t          s_jog_inflight_ms  = 0;  // last send/ack — for stale recovery
-static const uint32_t    JOG_INFLIGHT_STALE_MS = 300;
-
-void jog_mark_sent() {
-    ++s_jog_inflight;
-    s_jog_inflight_ms = milliseconds();
-}
-void jog_reset_inflight() {
-    s_jog_inflight = 0;
-}
-int jog_inflight() {
-    if (s_jog_inflight > 0 && (milliseconds() - s_jog_inflight_ms) > JOG_INFLIGHT_STALE_MS) {
-        s_jog_inflight = 0;  // ack(s) presumed lost / FluidNC quiet — recover
+JogFlowControl jog_flow_control() {
+#ifdef USE_WIFI
+    if (wifi_use_uart_mode()) {
+        return JogFlowControl::Blocking;
     }
-    return s_jog_inflight;
+    if (wifi_use_espnow_mode()) {
+        return JogFlowControl::Timed;
+    }
+    return JogFlowControl::Window;
+#else
+    return JogFlowControl::Blocking;
+#endif
 }
+
+void send_jog_cancel() {
+#ifdef USE_WIFI
+    if (!wifi_use_uart_mode() && !wifi_use_espnow_mode()) {
+        wifi_discard_pending_text();
+        jog_window_reset();
+    }
+#endif
+    fnc_realtime(JogCancel);
+}
+
 static void vsend_linef(const char* fmt, va_list va) {
     static char buf[128];
     vsnprintf(buf, 128, fmt, va);
@@ -317,6 +334,9 @@ extern "C" void show_error(int error) {
 #endif
     errorExpire = milliseconds() + 1000;
     lastError   = error;
+    if (s_jog_window > 0) {
+        --s_jog_window;  // a rejected jog  ends 1 outstanding line
+    }
     if (json_in_progress()) {
         // "error:N" without a JSON wrapper ends an in-flight document.
         json_reset_depth();
@@ -335,10 +355,8 @@ extern "C" void show_ok() {
 #ifdef FNC_RX_TRACE
     dbg_printf("[rx-ok]\n");
 #endif
-    
-    if (s_jog_inflight > 0) {
-        --s_jog_inflight;
-        s_jog_inflight_ms = milliseconds();
+    if (s_jog_window > 0) {
+        --s_jog_window;
     }
     if (json_in_progress()) {
         // "ok" ends a reply; if a torn JSON doc was in flight, clean up.

--- a/src/FluidNCModel.h
+++ b/src/FluidNCModel.h
@@ -21,6 +21,12 @@ enum state_t {
     Disconnected,  // We can't talk to FluidNC
 };
 
+enum class JogFlowControl : uint8_t {
+    Blocking,  // UART: send_jog_line() waits for the response itself
+    Timed,     // Lossy networked (ESP-NOW): bound queued motion by estimated execution time
+    Window,    // Reliable networked (Telnet): bound un-acked $J lines (ok-counting)
+};
+
 // Variables and functions to model the state of the FluidNC controller
 
 extern state_t     state;
@@ -47,12 +53,14 @@ extern uint32_t           mySelectedTool;
 int num_digits();
 
 void send_line(const char* s, int timeout = 2000);
-void send_jog_line(const char* s);  // jog send without the "ok" handshake
+void send_jog_line(const char* s);  // nonblocking network jog send
 void send_linef(const char* fmt, ...);
 
-void jog_mark_sent();       // record that a jog line was just streamed
-int  jog_inflight();        // jogs sent but not yet acked (self-heals if stalled)
-void jog_reset_inflight();  // clear (on JogCancel / jog stop)
+JogFlowControl jog_flow_control();
+void send_jog_cancel();
+
+int  jog_window_outstanding();
+void jog_window_reset();
 
 const char* intToCStr(int val);
 const char* axisNumToCStr(int axis);

--- a/src/MultiJogScene.cpp
+++ b/src/MultiJogScene.cpp
@@ -9,12 +9,15 @@
 #include "System.h"  // dbg_printf()
 
 //   Jog tracing — enable with -DJOG_TRACE
+//   flow: 0=Blocking(UART) 1=Timed(ESP-NOW horizon) 2=Window(Telnet ok-count)
+//   o=<outstanding queue ms, Timed>  w=<un-acked $J lines, Window>
 //   J s  send   t=<ms> a=<accum> dt=<ms since last send> f=<feed mm/min>
-//               e=<estimated exec ms> o=<outstanding queue ms> b=<send block ms>
+//               e=<estimated exec ms> o=<...> w=<...> b=<send block ms>
 //   J rev        direction reversal -> JogCancel issued
-//   J DROP       jog skipped because outstanding queue >= QUEUE_CAP_MS
+//   J DROP       dynamic jog skipped: flow control says hold (o>=cap or w>=window)
 //   J STOP       dial-still timeout -> jog cancelled
 //   J P  send   precise-mode send (b=<send block ms>)
+//   J WAIT queue precise: holding because flow control says hold (see o / w)
 #ifdef JOG_TRACE
 #    define JOG_DBG(...) dbg_printf(__VA_ARGS__)
 #else
@@ -124,9 +127,9 @@ private:
     // jog command per MPG_INTERVAL_MS to avoid flooding FluidNC's planner queue.
     static const uint32_t MPG_INTERVAL_MS = 30;   // min spacing between jog commands
     static const uint32_t MPG_STOP_MS     = 280;  // dial-still time that ends a jog
-    static const uint32_t QUEUE_CAP_MS    = 180;  // max motion kept buffered ahead
-    
-    static const int      JOG_MAX_INFLIGHT = 3;
+    static const uint32_t QUEUE_CAP_MS    = 180;  // max motion kept buffered ahead (Timed)
+
+    static const int      JOG_WINDOW = 8;
 
     static const uint32_t CANCEL_RESEND_MS = 80;
     static const uint32_t CANCEL_MIN_MS    = 250;
@@ -140,6 +143,35 @@ private:
     bool     _cancel_pending   = false;
     uint32_t _cancel_req_ms    = 0;
     uint32_t _last_cancel_ms   = 0;
+
+    uint32_t jog_outstanding_ms(uint32_t now) const {
+        int32_t remaining = (int32_t)(_jog_drain_ms - now);
+        return remaining > 0 ? (uint32_t)remaining : 0;
+    }
+
+    bool jog_send_blocked(uint32_t now) {
+        switch (jog_flow_control()) {
+            case JogFlowControl::Window:
+                return jog_window_outstanding() >= JOG_WINDOW;
+            case JogFlowControl::Timed:
+                return jog_outstanding_ms(now) >= QUEUE_CAP_MS;
+            default:
+                return false;
+        }
+    }
+
+    void reset_jog_runtime() {
+        _continuous       = false;
+        _mpg_jogging      = false;
+        _mpg_accum        = 0;
+        _last_mpg_ms      = 0;
+        _last_mpg_tick_ms = 0;
+        _jog_dir          = 0;
+        _jog_drain_ms     = 0;
+        _cancel_pending   = false;
+        _cancelling       = false;
+        _cancel_held      = false;
+    }
 
 public:
     MultiJogScene() : Scene("Jog", 4, jog_help_text) {}
@@ -341,16 +373,9 @@ public:
     }
     void cancel_jog() {
         bool was_jogging = _continuous || _mpg_jogging || (state == Jog);
-        _continuous       = false;
-        _mpg_jogging      = false;
-        _mpg_accum        = 0;
-        _last_mpg_ms      = 0;
-        _last_mpg_tick_ms = 0;
-        _jog_dir          = 0;
-        _jog_drain_ms     = 0;
-        jog_reset_inflight();
+        reset_jog_runtime();
         if (was_jogging) {
-            fnc_realtime(JogCancel);
+            send_jog_cancel();
             _cancel_pending = true;
             _cancelling     = true;
             _cancel_req_ms  = millis();
@@ -564,6 +589,13 @@ public:
     }
 
     void service_mpg(bool force = false) {
+        if (state == Disconnected) {
+            reset_jog_runtime();
+            return;
+        }
+        if (_cancel_pending) {
+            return;
+        }
         if (_mpg_accum == 0) {
             return;
         }
@@ -573,16 +605,17 @@ public:
         }
 
         int dir = (_mpg_accum > 0) ? 1 : -1;
+        JogFlowControl flow = jog_flow_control();
 
         if (_jog_dir != 0 && dir != _jog_dir) {
             JOG_DBG("J rev t=%u %d->%d\n", (unsigned)now, _jog_dir, dir);
-            fnc_realtime(JogCancel);
-            jog_reset_inflight();
+            send_jog_cancel();
+            _cancel_pending = true;
+            _cancelling     = true;
+            _cancel_req_ms  = now;
+            _last_cancel_ms = now;
+            _jog_dir        = 0;
             _jog_drain_ms = now;
-        }
-
-        if (!force && jog_inflight() >= JOG_MAX_INFLIGHT) {
-            JOG_DBG("J WAIT t=%u a=%d if=%d\n", (unsigned)now, _mpg_accum, jog_inflight());
             return;
         }
 
@@ -603,9 +636,11 @@ public:
         e4_t     f_min  = e4_from_int(inInches ? 40 : 1000);
         e4_t     feed   = (feed64 > f_max) ? f_max : (feed64 < f_min ? f_min : (e4_t)feed64);
 
-        uint32_t outstanding = (_jog_drain_ms > now) ? (_jog_drain_ms - now) : 0;
-        if (!force && outstanding >= QUEUE_CAP_MS) {
-            JOG_DBG("J DROP t=%u a=%d o=%u\n", (unsigned)now, _mpg_accum, (unsigned)outstanding);
+        uint32_t outstanding =
+            flow == JogFlowControl::Timed ? jog_outstanding_ms(now) : 0;
+        if (jog_send_blocked(now)) {
+            JOG_DBG("J DROP t=%u a=%d w=%d o=%u\n", (unsigned)now, _mpg_accum,
+                    jog_window_outstanding(), (unsigned)outstanding);
             _mpg_accum   = 0;
             _last_mpg_ms = now;
             return;
@@ -614,18 +649,19 @@ public:
         int      acc = _mpg_accum;  // captured for trace
         uint32_t t0  = millis();
         send_mpg_jog(_mpg_accum, feed);
-        jog_mark_sent();
-        uint32_t blk = millis() - t0;  // time spent ack-gated waiting for the prior "ok"
+        uint32_t blk = millis() - t0;
         _jog_dir = dir;
 
         // Track the estimated buffer drain time
         uint32_t exec_ms = (uint32_t)((int64_t)move * 60000 / feed);
-        uint32_t base    = (_jog_drain_ms > now) ? _jog_drain_ms : now;
-        _jog_drain_ms    = base + exec_ms;
+        if (flow == JogFlowControl::Timed) {
+            _jog_drain_ms = now + outstanding + exec_ms;
+        }
 
-        JOG_DBG("J s t=%u a=%d dt=%u f=%ld e=%u o=%u b=%u\n",
+        JOG_DBG("J s t=%u a=%d dt=%u f=%ld e=%u o=%u w=%d b=%u flow=%d\n",
                 (unsigned)now, acc, (unsigned)dt, (long)(feed / 10000),
-                (unsigned)exec_ms, (unsigned)outstanding, (unsigned)blk);
+                (unsigned)exec_ms, (unsigned)outstanding,
+                jog_window_outstanding(), (unsigned)blk, (int)flow);
 
         _mpg_accum   = 0;
         _last_mpg_ms = now;
@@ -634,22 +670,42 @@ public:
     // Precise mode: move by exactly (detents x step size). Each finite $J
     // completes on its own, so the final position always equals the dialed-in count
     void precise_flush() {
+        if (state == Disconnected) {
+            reset_jog_runtime();
+            return;
+        }
         if (_mpg_accum == 0) {
             return;
         }
         uint32_t now = millis();
         if ((now - _last_mpg_ms) >= MPG_INTERVAL_MS) {
-            if (jog_inflight() >= JOG_MAX_INFLIGHT) {
-                JOG_DBG("J WAIT t=%u a=%d if=%d\n", (unsigned)now, _mpg_accum, jog_inflight());
+            JogFlowControl flow = jog_flow_control();
+            e4_t     move = mpg_move_distance(_mpg_accum);
+            e4_t     feed = e4_from_int(inInches ? 400 : 10000);
+            uint32_t outstanding =
+                flow == JogFlowControl::Timed ? jog_outstanding_ms(now) : 0;
+            if (jog_send_blocked(now)) {
+                JOG_DBG("J WAIT queue t=%u a=%d w=%d o=%u\n",
+                        (unsigned)now, _mpg_accum,
+                        jog_window_outstanding(), (unsigned)outstanding);
                 return;
             }
+
             _cancel_pending = false;
             _cancelling     = false;
             int      acc = _mpg_accum;
             uint32_t t0  = millis();
-            send_mpg_jog(_mpg_accum, e4_from_int(inInches ? 400 : 10000));
-            jog_mark_sent();
-            JOG_DBG("J P t=%u a=%d b=%u\n", (unsigned)now, acc, (unsigned)(millis() - t0));
+            send_mpg_jog(_mpg_accum, feed);
+
+            uint32_t exec_ms = (uint32_t)((int64_t)move * 60000 / feed);
+            if (flow == JogFlowControl::Timed) {
+                _jog_drain_ms = now + outstanding + exec_ms;
+            }
+
+            JOG_DBG("J P t=%u a=%d e=%u o=%u w=%d b=%u flow=%d\n",
+                    (unsigned)now, acc, (unsigned)exec_ms,
+                    (unsigned)outstanding, jog_window_outstanding(),
+                    (unsigned)(millis() - t0), (int)flow);
             _mpg_accum   = 0;
             _last_mpg_ms = now;
         }
@@ -679,6 +735,10 @@ public:
     }
 
     void onPoll() override {
+        if (state == Disconnected) {
+            reset_jog_runtime();
+            return;
+        }
         if (dynamic_jog_active()) {
             service_mpg();
             // Stop jogging once the dial has been still long enough
@@ -702,20 +762,20 @@ public:
             if ((state != Jog && since >= CANCEL_MIN_MS) || since >= CANCEL_MAX_MS) {
                 _cancel_pending = false;
             } else if ((now - _last_cancel_ms) >= CANCEL_RESEND_MS) {
-                fnc_realtime(JogCancel);
+                send_jog_cancel();
                 _last_cancel_ms = now;
             }
         }
     }
 
     void onDROChange() {
-        reDisplay();
+        request_redisplay();
     }
     void onLimitsChange() {
-        reDisplay();
+        request_redisplay();
     }
     void onAlarm() {
-        reDisplay();
+        request_redisplay();
     }
     void onExit() {
         cancel_jog();

--- a/src/PeerLink.cpp
+++ b/src/PeerLink.cpp
@@ -191,6 +191,14 @@ enum class LinkState : uint8_t {
     Reconnecting,
 };
 
+enum class KeepaliveResult : uint8_t {
+    Rejected,
+    NewPlainSession,
+    Authenticated,
+    AuthenticatedConfirmed,
+    DuplicatePlain,
+};
+
 static LinkState        _link_state       = LinkState::Unpaired;
 static uint32_t         _link_state_since_ms = 0;
 static bool             _pairing_complete = false;
@@ -573,6 +581,7 @@ static void begin_reconnecting() {
         return;
     }
 
+    _tx_len = 0;
     reset_link_session();
     _last_rx_ms = 0;
     _reconnect_probe_idx = 0;
@@ -596,22 +605,28 @@ static void begin_synchronizing(uint8_t channel) {
     _synchronize_authenticated_tx = send_keepalive(_peer_mac);
 }
 
-static int accept_keepalive(const uint8_t* data, int len) {
+static KeepaliveResult accept_keepalive(const uint8_t* data, int len) {
     if (len == AUTH_KEEPALIVE_SIZE) {
         uint32_t advertised, nonce, counter;
         memcpy(&advertised, data + 1, 4);
         memcpy(&nonce,      data + 5, 4);
         memcpy(&counter,    data + 9, 4);
-        if (!ESPNowCrypto::acceptReplay(_rx_nonce, _rx_replay, nonce, counter, millis()) || advertised == 0) return 0;
+        if (!ESPNowCrypto::acceptReplay(
+                _rx_nonce, _rx_replay, nonce, counter, millis()) ||
+            advertised == 0) {
+            return KeepaliveResult::Rejected;
+        }
         _tx_peer_nonce.store(advertised, std::memory_order_release);
         _tx_peer_known.store(true, std::memory_order_release);
-        return (data[1 + 4 + ART_TAG_SIZE] & KEEPALIVE_SESSION_CONFIRMED) ? 3 : 2;
+        return (data[1 + 4 + ART_TAG_SIZE] & KEEPALIVE_SESSION_CONFIRMED)
+                   ? KeepaliveResult::AuthenticatedConfirmed
+                   : KeepaliveResult::Authenticated;
     }
 
     if (len == 5) {
         uint32_t advertised;
         memcpy(&advertised, data + 1, 4);
-        if (advertised == 0) return 0;
+        if (advertised == 0) return KeepaliveResult::Rejected;
 
         bool new_session =
             !_tx_peer_known.load(std::memory_order_acquire) ||
@@ -623,10 +638,11 @@ static int accept_keepalive(const uint8_t* data, int len) {
             ESPNowCrypto::issueRxChallenge(_rx_nonce);
             _rx_replay = {};
         }
-        return 1;
+        return new_session ? KeepaliveResult::NewPlainSession
+                           : KeepaliveResult::DuplicatePlain;
     }
 
-    return 0;
+    return KeepaliveResult::Rejected;
 }
 
 static void new_pairing_session_id() {
@@ -940,13 +956,15 @@ static void process_rx_packet(const RxPacket& packet) {
     }
 
     if (pkt_type == PKT_KEEPALIVE) {
-        int keepalive_state = accept_keepalive(data, len);
-        if (keepalive_state == 2 || keepalive_state == 3) {
+        KeepaliveResult keepalive = accept_keepalive(data, len);
+        if (keepalive == KeepaliveResult::Authenticated ||
+            keepalive == KeepaliveResult::AuthenticatedConfirmed) {
             note_rx_channel(packet.channel);
             if (_link_state == LinkState::Reconnecting) {
                 begin_synchronizing(packet.channel);
             } else if (_link_state == LinkState::Synchronizing) {
-                if (keepalive_state == 3 && _synchronize_authenticated_tx) {
+                if (keepalive == KeepaliveResult::AuthenticatedConfirmed &&
+                    _synchronize_authenticated_tx) {
                     set_connected_now();
                     update_rx_time();
                 } else {
@@ -957,9 +975,21 @@ static void process_rx_packet(const RxPacket& packet) {
                 set_connected_now();
                 update_rx_time();
             }
-        } else if (keepalive_state == 1) {
+        } else if (keepalive == KeepaliveResult::NewPlainSession) {
             note_rx_channel(packet.channel);
             begin_synchronizing(packet.channel);
+        } else if (keepalive == KeepaliveResult::DuplicatePlain) {
+            note_rx_channel(packet.channel);
+            if (_link_state == LinkState::Synchronizing ||
+                _link_state == LinkState::Connected) {
+                // A valid (replay-checked) duplicate keepalive is still proof the
+                // peer is alive. Feed the RX watchdog (_last_rx_ms) so a steady
+                // stream of these isn't mistaken for silence and doesn't trigger a
+                // needless reconnect; also refresh the model-level link timer.
+                _last_rx_ms = millis();
+                update_rx_time();
+                send_keepalive(_peer_mac);
+            }
         }
         return;
     }

--- a/src/PeerLink.cpp
+++ b/src/PeerLink.cpp
@@ -26,7 +26,6 @@
 #define PREF_NAMESPACE             "fluidespnow"
 #define ESPNOW_PAIR_CHANNEL        1
 #define BEACON_INTERVAL_MS         250
-#define PAIRING_SESSION_LIFETIME_MS 60000
 #define PAIR_RESULT_TIMEOUT_MS     5000
 #define PAIR_CONFIRM_RETRY_MS      300
 #define PAIR_COMPLETE_RETRY_MS     100
@@ -220,7 +219,6 @@ static uint32_t         _pairing_last_completion_ms = 0;
 static uint32_t         _pairing_last_confirm_ms = 0;
 static uint32_t         _pairing_await_result_ms = 0;
 static uint32_t         _beacon_last_ms   = 0;
-static uint32_t         _pairing_start_ms = 0;
 static uint8_t          _probe_idx        = 0;
 
 static uint8_t  _reconnect_probe_idx = 0;
@@ -1397,16 +1395,6 @@ void espnow_poll() {
         return;
     }
 
-    if ((now - _pairing_start_ms) >= PAIRING_SESSION_LIFETIME_MS) {
-        clear_temporary_pairing_peer();
-        clear_pairing_secrets();
-        _pairing_start_ms = now;
-        new_pairing_session_id();
-        _pairing_keypair_valid =
-            ESPNowCrypto::generateEcdhKeypair(_pairing_private_key, _pairing_public_key);
-        set_link_state(LinkState::Discovering);
-    }
-
     if (_link_state == LinkState::Confirming) {
         static uint32_t last_result_wait_log_ms = 0;
         if (!_pairing_completion_pending &&
@@ -1582,7 +1570,6 @@ void espnow_start_pairing() {
         ESPNowCrypto::generateEcdhKeypair(_pairing_private_key, _pairing_public_key);
     new_pairing_session_id();
 
-    _pairing_start_ms = millis();
     set_link_state(LinkState::Discovering);
     _pairing_complete = false;
     _beacon_last_ms   = 0;

--- a/src/SystemMacOS.cpp
+++ b/src/SystemMacOS.cpp
@@ -326,6 +326,7 @@ WiFiConfig  wifi_active_config()           { return _preview_cfg; }
 void        ws_putchar(uint8_t)            {}
 int         ws_getchar()                   { return -1; }
 bool          wifi_use_uart_mode()            { return false; }
+void          wifi_discard_pending_text()     {}
 void          wifi_set_uart_mode(bool)        {}
 bool          wifi_is_first_boot()            { return false; }
 TransportMode wifi_get_transport()            { return TransportMode::ESPNOW; }

--- a/src/SystemMacOS_CYD.cpp
+++ b/src/SystemMacOS_CYD.cpp
@@ -370,6 +370,7 @@ WiFiConfig  wifi_active_config()                         { return _preview_cfg; 
 void        ws_putchar(uint8_t)                          {}
 int         ws_getchar()                                 { return -1; }
 bool          wifi_use_uart_mode()                           { return false; }
+void          wifi_discard_pending_text()                    {}
 void          wifi_set_uart_mode(bool)                       {}
 bool          wifi_is_first_boot()                           { return false; }
 TransportMode wifi_get_transport()                           { return TransportMode::ESPNOW; }

--- a/src/WiFiConnection.cpp
+++ b/src/WiFiConnection.cpp
@@ -47,6 +47,8 @@ extern const char* git_info;
 #define TEST_FLUIDNC_IP    "192.168.0.1"
 #define RX_BUF_SIZE        2048
 #define TX_BUF_SIZE        512
+#define TX_PENDING_SIZE    2048
+#define RT_PENDING_SIZE    32
 #define STATUS_POLL_MS     500         // Send '?' every 500 ms while connected
 #define WIFI_RETRY_DELAY_MS 15000     // Retry WiFi.begin() this long after a failure
 #define DNS_RETRY_DELAY_MS  5000     // Retry hostname resolution this long after a failure
@@ -97,6 +99,13 @@ static int     _rx_tail = 0;
 // Line buffer for outgoing text (GCode / $ commands).
 static uint8_t _tx_buf[TX_BUF_SIZE];
 static int     _tx_len = 0;
+static uint8_t _tx_pending[TX_PENDING_SIZE];
+static int     _tx_pending_head = 0;
+static int     _tx_pending_tail = 0;
+static uint8_t _rt_pending[RT_PENDING_SIZE];
+static int     _rt_pending_head = 0;
+static int     _rt_pending_tail = 0;
+static bool    _rt_status_pending = false;
 
 // Timers.
 static uint32_t _last_status_ms = 0;
@@ -192,9 +201,24 @@ static void tcp_close() {
     }
     _tcp_connect_deadline_ms = 0;
     _ws_connected = false;
+    _tx_len = 0;
+    _tx_pending_head = 0;
+    _tx_pending_tail = 0;
+    _rt_pending_head = 0;
+    _rt_pending_tail = 0;
+    _rt_status_pending = false;
+    _rx_tail = _rx_head;
     // Any JSON document still being streamed across chunks is now lost;
     // reset the depth tracker so the next document starts cleanly.
     json_reset_depth();
+}
+
+static void tcp_fail_and_reconnect() {
+    tcp_close();
+    set_disconnected_state();
+    if (_ws_started) {
+        _tcp_next_try_ms = millis() + TCP_RECONNECT_DELAY_MS;
+    }
 }
 
 static void tcp_apply_opts(int fd) {
@@ -344,45 +368,128 @@ static const char* wifi_status_name(wl_status_t status) {
     }
 }
 
-// Bulk send over the raw socket. `flags` is passed to send(); pass MSG_DONTWAIT
-// for the gcode/jog stream so a backpressured socket never blocks the main loop
-// (see ws_send_text). transient EAGAIN drops the remainder of this flush but
-// keeps the socket so the in-flight document survives. Any other errno tears the
-// socket down so wifi_poll() can reconnect.
-static bool tcp_send_all(const uint8_t* payload, size_t length, int flags) {
+static int tcp_realtime_pending_free() {
+    int used = (_rt_pending_head - _rt_pending_tail + RT_PENDING_SIZE) %
+               RT_PENDING_SIZE;
+    return RT_PENDING_SIZE - used - 1;
+}
+
+static bool tcp_flush_realtime() {
+    while (_sock >= 0 && _rt_pending_tail != _rt_pending_head) {
+        uint8_t c = _rt_pending[_rt_pending_tail];
+        ssize_t n = ::send(_sock, &c, 1, MSG_DONTWAIT);
+        if (n == 1) {
+            _rt_pending_tail = (_rt_pending_tail + 1) % RT_PENDING_SIZE;
+            if (c == '?') {
+                _rt_status_pending = false;
+            }
+            continue;
+        }
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            return true;
+        }
+
+        dbg_printf("Telnet: realtime send errno=%d\n", n < 0 ? errno : 0);
+        tcp_fail_and_reconnect();
+        return false;
+    }
+    return _sock >= 0;
+}
+
+static bool tcp_queue_realtime(const uint8_t* payload, size_t length) {
     if (_sock < 0 || length == 0) {
         return _sock >= 0;
     }
-    size_t off = 0;
-    while (off < length) {
-        ssize_t n = ::send(_sock, payload + off, length - off, flags);
-        if (n <= 0) {
-            int e = errno;
-            if (e == EAGAIN || e == EWOULDBLOCK) {
-                dbg_printf("Telnet: send EAGAIN dropped=%u of %u\n",
-                           (unsigned)(length - off), (unsigned)length);
-                return true;
-            }
-            dbg_printf("Telnet: send errno=%d off=%u/%u\n",
-                       e, (unsigned)off, (unsigned)length);
-            tcp_close();
-            set_disconnected_state();
+
+    for (size_t i = 0; i < length; ++i) {
+        uint8_t c = payload[i];
+        if (c == '?' && _rt_status_pending) {
+            continue;
+        }
+        if (tcp_realtime_pending_free() == 0) {
+            dbg_println("Telnet: realtime queue saturated");
+            tcp_fail_and_reconnect();
             return false;
         }
-        off += (size_t)n;
+        if (c == JogCancel) {
+            _rt_pending_tail =
+                (_rt_pending_tail + RT_PENDING_SIZE - 1) % RT_PENDING_SIZE;
+            _rt_pending[_rt_pending_tail] = c;
+        } else {
+            _rt_pending[_rt_pending_head] = c;
+            _rt_pending_head = (_rt_pending_head + 1) % RT_PENDING_SIZE;
+        }
+        if (c == '?') {
+            _rt_status_pending = true;
+        }
     }
-    return true;
+    return tcp_flush_realtime();
 }
 
-// Keep the ws_send_text/ws_send_bin spellings for the ws_putchar
-// callsites — both go through the same raw send() now.
+static int tcp_tx_pending_free() {
+    int used = (_tx_pending_head - _tx_pending_tail + TX_PENDING_SIZE) %
+               TX_PENDING_SIZE;
+    return TX_PENDING_SIZE - used - 1;
+}
+
+static bool tcp_flush_text() {
+    while (_sock >= 0 && _tx_pending_tail != _tx_pending_head) {
+        int contiguous = _tx_pending_head > _tx_pending_tail
+                             ? _tx_pending_head - _tx_pending_tail
+                             : TX_PENDING_SIZE - _tx_pending_tail;
+        ssize_t n = ::send(_sock, _tx_pending + _tx_pending_tail,
+                           (size_t)contiguous, MSG_DONTWAIT);
+        if (n > 0) {
+            _tx_pending_tail =
+                (_tx_pending_tail + (int)n) % TX_PENDING_SIZE;
+            continue;
+        }
+        if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            return true;
+        }
+
+        dbg_printf("Telnet: queued send errno=%d\n", n < 0 ? errno : 0);
+        tcp_fail_and_reconnect();
+        return false;
+    }
+    return _sock >= 0;
+}
+
+static bool tcp_flush_outgoing() {
+    if (!tcp_flush_realtime()) {
+        return false;
+    }
+    if (_rt_pending_tail != _rt_pending_head) {
+        return true;
+    }
+    return tcp_flush_text();
+}
+
+// Keep the ws_send_text/ws_send_bin spellings for the ws_putchar callsites.
+// Text is queued nonblocking; realtime controls bypass that queue.
 static bool ws_send_text(uint8_t* payload, size_t length) {
-    return tcp_send_all(payload, length, MSG_DONTWAIT);
+    if (_sock < 0 || length == 0) {
+        return _sock >= 0;
+    }
+    if (length > (size_t)tcp_tx_pending_free()) {
+        dbg_printf("Telnet: TX queue saturated (%u B pending, %u B new)\n",
+                   (unsigned)((_tx_pending_head - _tx_pending_tail +
+                               TX_PENDING_SIZE) % TX_PENDING_SIZE),
+                   (unsigned)length);
+        tcp_fail_and_reconnect();
+        return false;
+    }
+
+    for (size_t i = 0; i < length; ++i) {
+        _tx_pending[_tx_pending_head] = payload[i];
+        _tx_pending_head = (_tx_pending_head + 1) % TX_PENDING_SIZE;
+    }
+    return tcp_flush_outgoing();
 }
 
-// Realtime bytes ('?', '!', '~', JogCancel, …): kept blocking
+// Realtime bytes ('?', '!', '~', JogCancel, ...) have priority over queued text
 static bool ws_send_bin(const uint8_t* payload, size_t length) {
-    return tcp_send_all(payload, length, 0);
+    return tcp_queue_realtime(payload, length);
 }
 
 // Pull bytes off the socket and push them into the RX ring buffer. Called
@@ -411,12 +518,10 @@ static void tcp_refill_rx() {
         if (n <= 0) {
             if (n == 0) {
                 dbg_println("Telnet: peer closed");
-                tcp_close();
-                set_disconnected_state();
+                tcp_fail_and_reconnect();
             } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
                 dbg_printf("Telnet: recv errno=%d\n", errno);
-                tcp_close();
-                set_disconnected_state();
+                tcp_fail_and_reconnect();
             }
             return;
         }
@@ -534,6 +639,11 @@ void wifi_set_transport(TransportMode mode) {
 
 bool wifi_use_uart_mode()   { return wifi_get_transport() == TransportMode::UART; }
 bool wifi_use_espnow_mode() { return wifi_get_transport() == TransportMode::ESPNOW; }
+
+void wifi_discard_pending_text() {
+    _tx_len          = 0;
+    _tx_pending_tail = _tx_pending_head;
+}
 
 void wifi_set_uart_mode(bool uart) {
     wifi_set_transport(uart ? TransportMode::UART : TransportMode::WIFI);
@@ -1763,6 +1873,7 @@ void wifi_poll() {
         if (_connecting_fd >= 0) {
             tcp_poll_connect();
         } else if (_sock >= 0) {
+            tcp_flush_outgoing();
             tcp_refill_rx();
             // RX-stall watchdog. A healthy FluidNC answers the 500 ms '?' polls,
             // so prolonged total silence on a live socket means it's wedged half-open

--- a/src/WiFiConnection.h
+++ b/src/WiFiConnection.h
@@ -76,6 +76,7 @@ void          wifi_set_transport(TransportMode mode);
 
 bool wifi_use_uart_mode();
 bool wifi_use_espnow_mode();
+void wifi_discard_pending_text();
 
 void wifi_set_uart_mode(bool uart);
 


### PR DESCRIPTION
## Improvements

- Stream jog commands non-blockingly with transport-specific flow control.
- Use GRBL `ok` counting for Telnet and a "timed horizon" for ESP-NOW.
- Fix ESP-NOW reconnects by preventing duplicate keepalives from refreshing the link watchdog.
- Keep the pairing window open until the user exits pairing mode
- Activate `MenuScene` after switching ESP-NOW machines.