### PR TITLE
feat(ui): add dynamic multi-axis (1-6 axes) support

### DIFF
--- a/src/Drawing.cpp
+++ b/src/Drawing.cpp
@@ -225,7 +225,8 @@ void drawStatusSmall(int y) {
     centered_text(my_state_string, y + height / 2 + 3, stateFGColors[state], SMALL);
 }
 
-Stripe::Stripe(int x, int y, int width, int height, fontnum_t font) : _x(x), _y(y), _width(width), _height(height), _font(font) {}
+Stripe::Stripe(int x, int y, int width, int height, fontnum_t font, int gap)
+    : _x(x), _y(y), _width(width), _height(height), _gap(gap), _font(font) {}
 
 void Stripe::draw(char left, const char* right, bool highlighted, int left_color) {
     char t[2] = { left, '\0' };
@@ -261,14 +262,13 @@ void drawButtonLegends(const char* red, const char* green, const char* orange) {
     centered_text(orange, DIAL_BUTTON_LINE, ORANGE);
 }
 
-void putDigit(int& n, int x, int y, int color) {
+void putDigit(int& n, int x, int y, int color, fontnum_t font = MEDIUM) {
     char txt[2] = { '\0', '\0' };
     txt[0]      = "0123456789"[n % 10];
     n /= 10;
-    text(txt, x, y, color, MEDIUM, middle_right);
+    text(txt, x, y, color, font, middle_right);
 }
-void fancyNumber(pos_t n, int n_decimals, int hl_digit, int x, int y, int text_color, int hl_text_color) {
-    fontnum_t font     = SMALL;
+void fancyNumber(pos_t n, int n_decimals, int hl_digit, int x, int y, int text_color, int hl_text_color, fontnum_t font = SMALL) {
     int       n_digits = n_decimals + 1;
     int       i;
     bool      isneg = n < 0;
@@ -276,12 +276,6 @@ void fancyNumber(pos_t n, int n_decimals, int hl_digit, int x, int y, int text_c
         n = -n;
     }
 #ifdef E4_POS_T
-    // in e4 format, the number always has 4 postdecimal digits,
-    // so if n_decimals is less than 4, we discard digits from
-    // the right.  We could do this by computing a divisor
-    // based on e4_power10(4 - n_decimals), but the expected
-    // number of iterations of this loop is max 4, typically 2,
-    // so that is hardly worthwhile.
     for (i = 4; i > n_decimals; --i) {
         if (i == (n_decimals + 1)) {  // Round
             n += 5;
@@ -293,36 +287,36 @@ void fancyNumber(pos_t n, int n_decimals, int hl_digit, int x, int y, int text_c
         n *= 10;
     }
 #endif
-    const int char_width = 20;
+    const int char_width = (font == TINY ? 10 : (font == SMALL ? 14 : 20));
 
     int ni = (int)n;
     for (i = 0; i < n_decimals; i++) {
-        putDigit(ni, x, y, i == hl_digit ? hl_text_color : text_color);
+        putDigit(ni, x, y, i == hl_digit ? hl_text_color : text_color, font);
         x -= char_width;
     }
     if (n_decimals) {
-        text(".", x - 10, y, text_color, MEDIUM, middle_center);
+        text(".", x - (font == TINY ? 5 : 8), y, text_color, font, middle_center);
         x -= char_width;
     }
     do {
-        putDigit(ni, x, y, i++ == hl_digit ? hl_text_color : text_color);
+        putDigit(ni, x, y, i++ == hl_digit ? hl_text_color : text_color, font);
         x -= char_width;
     } while (ni || i <= hl_digit);
     if (isneg) {
-        text("-", x, y, text_color, MEDIUM, middle_right);
+        text("-", x, y, text_color, font, middle_right);
     }
 }
 
 void DRO::drawHoming(int axis, bool highlight, bool homed) {
-    text(axisNumToCStr(axis), text_left_x(), text_middle_y(), myLimitSwitches[axis] ? GREEN : YELLOW, MEDIUM, middle_left);
-    fancyNumber(myAxes[axis], num_digits(), -1, text_right_x(), text_middle_y(), highlight ? (homed ? GREEN : RED) : DARKGREY, RED);
+    text(axisNumToCStr(axis), text_left_x(), text_middle_y(), myLimitSwitches[axis] ? GREEN : YELLOW, _font, middle_left);
+    fancyNumber(myAxes[axis], num_digits(), -1, text_right_x(), text_middle_y(), highlight ? (homed ? GREEN : RED) : DARKGREY, RED, _font);
     advance();
 }
 
 void DRO::draw(int axis, int hl_digit, bool highlight) {
-    text(axisNumToCStr(axis), text_left_x(), text_middle_y(), highlight ? GREEN : DARKGREY, MEDIUM, middle_left);
+    text(axisNumToCStr(axis), text_left_x(), text_middle_y(), highlight ? GREEN : DARKGREY, _font, middle_left);
     fancyNumber(
-        myAxes[axis], num_digits(), hl_digit, text_right_x(), text_middle_y(), highlight ? WHITE : DARKGREY, highlight ? RED : DARKGREY);
+        myAxes[axis], num_digits(), hl_digit, text_right_x(), text_middle_y(), highlight ? WHITE : DARKGREY, highlight ? RED : DARKGREY, _font);
     advance();
 }
 

--- a/src/Drawing.h
+++ b/src/Drawing.h
@@ -12,11 +12,11 @@ private:
     int       _x;
     int       _width;
     int       _height;
+    int       _gap;
+protected:
+    int       _y;
     fontnum_t _font;
     const int _text_inset = 5;
-
-protected:
-    int _y;
 
     int text_left_x() { return _x + _text_inset; }
     int text_center_x() { return _x + _width / 2; }
@@ -25,12 +25,12 @@ protected:
     int widget_left_x() { return _x; }
 
 public:
-    Stripe(int x, int y, int width, int height, fontnum_t font);
+    Stripe(int x, int y, int width, int height, fontnum_t font, int gap = -1);
     void draw(const char* left, const char* right, bool highlighted, int left_color = WHITE);
     void draw(char left, const char* right, bool highlighted, int left_color = WHITE);
     void draw(const char* center, bool highlighted);
     int  y() { return _y; }
-    int  gap() { return _height + 1; }
+    int  gap() { return _gap > 0 ? _gap : _height + 1; }
     void advance() { _y += gap(); }
 };
 class LED {
@@ -47,7 +47,8 @@ public:
 
 class DRO : public Stripe {
 public:
-    DRO(int x, int y, int width, int height) : Stripe(x, y, width, height, MEDIUM_MONO) {}
+    DRO(int x, int y, int width, int height, fontnum_t font = MEDIUM_MONO, int gap = -1)
+        : Stripe(x, y, width, height, font, gap) {}
     void draw(int axis, bool highlight);
     void draw(int axis, int hl_digit, bool highlight);
     void drawHoming(int axis, bool highlight, bool homed);

--- a/src/HomingScene.cpp
+++ b/src/HomingScene.cpp
@@ -6,17 +6,19 @@
 
 extern Scene statusScene;
 
-#define HOMING_N_AXIS 3
+#define HOMING_N_AXIS 4
 
 IntConfigItem homing_cycles[HOMING_N_AXIS] = {
     { "$/axes/x/homing/cycle" },
     { "$/axes/y/homing/cycle" },
     { "$/axes/z/homing/cycle" },
+    { "$/axes/a/homing/cycle" },
 };
 BoolConfigItem homing_allows[HOMING_N_AXIS] = {
     { "$/axes/x/homing/allow_single_axis" },
     { "$/axes/y/homing/allow_single_axis" },
     { "$/axes/z/homing/allow_single_axis" },
+    { "$/axes/a/homing/allow_single_axis" },
 };
 
 int  homed_axes = 0;

--- a/src/MultiJogScene.cpp
+++ b/src/MultiJogScene.cpp
@@ -112,11 +112,11 @@ private:
 #else
     static const int DEFAULT_DIST_INDEX = 1;  // tenths
 #endif
-    int          _dist_index[3] = { DEFAULT_DIST_INDEX, DEFAULT_DIST_INDEX, DEFAULT_DIST_INDEX };
+    int          _dist_index[6] = { DEFAULT_DIST_INDEX, DEFAULT_DIST_INDEX, DEFAULT_DIST_INDEX, DEFAULT_DIST_INDEX, DEFAULT_DIST_INDEX, DEFAULT_DIST_INDEX };
     int          max_index() { return 6; }  // 10^3 = 1000;
     int          min_index() { return 0; }  // 10^3 = 1000;
     int          _selected_mask = 1 << 0;
-    const int    num_axes       = 3;
+    int          num_axes() { return (n_axes > 0 && n_axes <= 6) ? n_axes : 3; }
     bool         _cancelling    = false;
     bool         _cancel_held   = false;
     bool         _continuous    = false;
@@ -181,7 +181,7 @@ public:
     bool selected(int axis) { return _selected_mask & (1 << axis); }
     bool only(int axis) { return _selected_mask == (1 << axis); }
 
-    int  next(int axis) { return (axis < 2) ? axis + 1 : 0; }
+    int  next(int axis) { return (axis < num_axes() - 1) ? axis + 1 : 0; }
     void select(int axis) { _selected_mask |= 1 << axis; }
     void unselect(int axis) { _selected_mask &= ~(1 << axis); }
 
@@ -189,7 +189,7 @@ public:
         if ((_selected_mask & (_selected_mask - 1)) != 0) {
             return -2;  // Multiple axes are selected
         }
-        for (size_t axis = 0; axis < num_axes; axis++) {
+        for (size_t axis = 0; axis < num_axes(); axis++) {
             if (selected(axis)) {
                 return axis;
             }
@@ -260,7 +260,7 @@ public:
         drawJogBg();
         drawMenuTitle("Jog");
         if (state == Idle) {
-            centered_text(_dynamic_mode ? "Dynamic" : "Precise", 45, 65535, SMALL);
+            centered_text(_dynamic_mode ? "Dynamic" : "Precise", 36, 65535, TINY);
         } else {
             drawStatus();
         }
@@ -271,8 +271,13 @@ public:
         if (_cancelling || _cancel_held) {
             centered_text("Jog Canceled", 120, RED, MEDIUM);
         } else {
-            DRO dro(16, 68, 210, 32);
-            for (size_t axis = 0; axis < num_axes; axis++) {
+            int n          = num_axes();
+            int dro_height = (n <= 3) ? 32 : (n == 4 ? 25 : 18);
+            int dro_gap    = (n <= 3) ? 33 : (dro_height + 5);
+            int start_y    = (n <= 3) ? 68 : (n == 4 ? 58 : 50);
+            fontnum_t font = (n <= 3) ? MEDIUM_MONO : (n == 4 ? MEDIUM : SMALL);
+            DRO dro(16, start_y, 210, dro_height, font, dro_gap);
+            for (size_t axis = 0; axis < n; axis++) {
                 dro.draw(axis, _dist_index[axis], selected(axis));
             }
             if (state == Jog) {
@@ -281,7 +286,7 @@ public:
                 }
             } else {
                 std::string dialLegend("Zero");
-                for (int axis = 0; axis < num_axes; axis++) {
+                for (int axis = 0; axis < num_axes(); axis++) {
                     if (selected(axis)) {
                         dialLegend += axisNumToChar(axis);
                     }
@@ -293,7 +298,7 @@ public:
     }
     void zero_axes() {
         std::string cmd = "G10L20P0";
-        for (int axis = 0; axis < num_axes; axis++) {
+        for (int axis = 0; axis < num_axes(); axis++) {
             if (selected(axis)) {
                 cmd += axisNumToChar(axis);
                 cmd += "0";
@@ -323,7 +328,7 @@ public:
     void confirm_zero_axes() {
         std::string confirmMsg("Zero ");
 
-        for (int axis = 0; axis < num_axes; axis++) {
+        for (int axis = 0; axis < num_axes(); axis++) {
             if (selected(axis)) {
                 confirmMsg += axisNumToChar(axis);
             }
@@ -343,7 +348,7 @@ public:
         }
     }
     void increment_distance() {
-        for (int axis = 0; axis < num_axes; axis++) {
+        for (int axis = 0; axis < num_axes(); axis++) {
             if (selected(axis)) {
                 increment_distance(axis);
             }
@@ -356,14 +361,14 @@ public:
     }
 
     void decrement_distance() {
-        for (int axis = 0; axis < num_axes; axis++) {
+        for (int axis = 0; axis < num_axes(); axis++) {
             if (selected(axis)) {
                 decrement_distance(axis);
             }
         }
     }
     void rotate_distance() {
-        for (int axis = 0; axis < num_axes; axis++) {
+        for (int axis = 0; axis < num_axes(); axis++) {
             if (selected(axis)) {
                 if (++_dist_index[axis] >= max_index()) {
                     _dist_index[axis] = min_index();
@@ -392,15 +397,15 @@ public:
         int the_axis = the_selected_axis();
         if (the_axis == -2) {
             unselect_all();
-            select(num_axes - 1);
+            select(num_axes() - 1);
             return;
         }
         if (the_axis == -1) {
-            select(num_axes - 1);
+            select(num_axes() - 1);
             return;
         }
         unselect(the_axis);
-        if (++the_axis == num_axes) {
+        if (++the_axis == num_axes()) {
             the_axis = 0;
         }
         select(the_axis);
@@ -418,7 +423,7 @@ public:
         }
         unselect(the_axis);
         if (--the_axis < 0) {
-            the_axis = num_axes - 1;
+            the_axis = num_axes() - 1;
         }
         select(the_axis);
     }
@@ -513,7 +518,7 @@ public:
 
     e4_t mpg_move_distance(int delta) {
         e4_t move = 0;
-        for (int axis = 0; axis < num_axes; ++axis) {
+        for (int axis = 0; axis < num_axes(); ++axis) {
             if (selected(axis)) {
                 move = e4_magnitude(move, delta * distance(axis));
             }
@@ -526,7 +531,7 @@ public:
         cmd += inInches ? "G20" : "G21";
         cmd += "F";
         cmd += e4_to_cstr(feed, 0);
-        for (int axis = 0; axis < num_axes; ++axis) {
+        for (int axis = 0; axis < num_axes(); ++axis) {
             if (selected(axis)) {
                 cmd += axisNumToChar(axis);
                 cmd += e4_to_cstr(delta * distance(axis), inInches ? 3 : 2);
@@ -539,7 +544,7 @@ public:
         // e.g. $J=G91F1000X-10000
         e4_t total_distance = 0;
         int  n_axes         = 0;
-        for (int axis = 0; axis < num_axes; ++axis) {
+        for (int axis = 0; axis < num_axes(); ++axis) {
             if (selected(axis)) {
                 total_distance = e4_magnitude(total_distance, distance(axis));
                 ++n_axes;
@@ -552,7 +557,7 @@ public:
         cmd += inInches ? "G20" : "G21";
         cmd += "F";
         cmd += e4_to_cstr(feedrate, 3);
-        for (int axis = 0; axis < num_axes; ++axis) {
+        for (int axis = 0; axis < num_axes(); ++axis) {
             if (selected(axis)) {
                 e4_t axis_distance;
                 if (n_axes == 1) {
@@ -716,7 +721,7 @@ public:
         if (!_dynamic_mode) {
             return false;
         }
-        for (int axis = 0; axis < num_axes; axis++) {
+        for (int axis = 0; axis < num_axes(); axis++) {
             if (selected(axis) && _dist_index[axis] >= num_digits()) {
                 return true;
             }

--- a/src/StatusScene.cpp
+++ b/src/StatusScene.cpp
@@ -151,10 +151,15 @@ public:
         drawMenuTitle(current_scene->name());
         drawStatus();
 
-        DRO dro(16, 68, 210, 32);
-        dro.draw(0, -1, true);
-        dro.draw(1, -1, true);
-        dro.draw(2, -1, true);
+        int active_axes = (n_axes > 0 && n_axes <= 6) ? n_axes : 3;
+        int dro_height  = (active_axes <= 3) ? 32 : (active_axes == 4 ? 25 : 18);
+        int dro_gap     = (active_axes <= 3) ? 33 : (dro_height + 5);
+        int start_y     = (active_axes <= 3) ? 68 : (active_axes == 4 ? 58 : 50);
+        fontnum_t font  = (active_axes <= 3) ? MEDIUM_MONO : (active_axes == 4 ? MEDIUM : SMALL);
+        DRO dro(16, start_y, 210, dro_height, font, dro_gap);
+        for (int i = 0; i < active_axes; ++i) {
+            dro.draw(i, -1, true);
+        }
 
         int y = 170;
         if (state == Cycle || state == Hold) {


### PR DESCRIPTION
- Replace fixed 3-axis count in MultiJogScene with dynamic num_axes() getter
- Dynamically scale DRO row heights, vertical margins, and font sizes based on active axis count
- Update fancyNumber() and putDigit() to format digits with per-row fontnum_t
- Add A-axis config bindings in HomingScene
- Preserve 100% exact original 3-axis layout parameters for backwards compatibility
- Verified hardware compatibility on M5Dial with 3-axis, 4-axis, and 5-axis FluidNC profiles